### PR TITLE
client-web Add status bar with information about sync process

### DIFF
--- a/client-web/src/app/api.ts
+++ b/client-web/src/app/api.ts
@@ -1,31 +1,15 @@
 import { API, Keys, Request } from "../../bridge/pkg/qqself_client_web_bridge"
 
-interface ApiError {
+export interface APIProvider {
+  set: (encryptedPayload: string) => Promise<string>
+  find: (encryptedPayload: string) => Promise<EncryptedEntry[]>
+  deleteAccount: (keys: Keys) => Promise<void>
+}
+
+export interface ApiError {
   timestamp: number
   error_code: string
   error: string
-}
-
-const http = async (req: Request): Promise<Response> => {
-  const url = req.url.replace("https://api.qqself.com", import.meta.env.VITE_API_HOST)
-  const resp = await fetch(url, {
-    method: "POST",
-    body: req.payload,
-    headers: {
-      "Content-Type": req.contentType,
-    },
-  })
-  if (resp.status != 200) {
-    const err = (await resp.json()) as ApiError
-    throw new Error("API error: " + err.error)
-  }
-  return resp
-}
-
-// Call Set sync API endpoint
-export const set = async (encryptedPayload: string): Promise<string> => {
-  const resp = await http(API.createApiSetRequest(encryptedPayload))
-  return resp.text()
 }
 
 export interface EncryptedEntry {
@@ -33,35 +17,61 @@ export interface EncryptedEntry {
   payload: string
 }
 
-// Call Find sync API endpoint
-export const find = async (encryptedPayload: string): Promise<EncryptedEntry[]> => {
-  const resp = await http(API.createApiFindRequest(encryptedPayload))
-  if (!resp.body) {
-    throw new Error("API find error: no body")
-  }
-  const lines = await resp.text()
-  if (!lines) {
-    return [] // Find returned no lines
-  }
-  return lines
-    .split("\n")
-    .filter((v) => v) // Filter out empty lines
-    .map((v) => {
-      // TODO This is ugly manual id parsing, parse it properly via PayloadId::parse
-      const entry = v.split(":")
-      return { id: entry[0], payload: entry[1] }
+export class ServerApi implements APIProvider {
+  async http(req: Request): Promise<Response> {
+    // TODO Requests are coming from WebAssembly bridge with host name already set
+    //      here we override it if needed depending on a config. Make it configurable
+    //      in the bridge itself
+    const url = req.url.replace("https://api.qqself.com", import.meta.env.VITE_API_HOST)
+    const resp = await fetch(url, {
+      method: "POST",
+      body: req.payload,
+      headers: {
+        "Content-Type": req.contentType,
+      },
     })
-}
+    if (resp.status != 200) {
+      const err = (await resp.json()) as ApiError
+      throw new Error("API error: " + err.error)
+    }
+    return resp
+  }
 
-// Call Delete sync API endpoint
-export const deleteAccount = async (keys: Keys): Promise<void> => {
-  await http(API.createApiDeleteRequest(keys))
+  async set(encryptedPayload: string): Promise<string> {
+    const resp = await this.http(API.createApiSetRequest(encryptedPayload))
+    return resp.text()
+  }
+
+  async find(encryptedPayload: string): Promise<EncryptedEntry[]> {
+    const resp = await this.http(API.createApiFindRequest(encryptedPayload))
+    if (!resp.body) {
+      throw new Error("API find error: no body")
+    }
+    const lines = await resp.text()
+    if (!lines) {
+      return [] // Find returned no lines
+    }
+    return lines
+      .split("\n")
+      .filter((v) => v) // Filter out empty lines
+      .map((v) => {
+        // TODO This is ugly manual id parsing, parse it properly via PayloadId::parse
+        const entry = v.split(":")
+        return { id: entry[0], payload: entry[1] }
+      })
+  }
+
+  async deleteAccount(keys: Keys): Promise<void> {
+    await this.http(API.createApiDeleteRequest(keys))
+  }
 }
 
 if (import.meta.vitest) {
   const { describe, test, expect } = import.meta.vitest
 
   const wait = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000))
+
+  const api = new ServerApi()
 
   describe("API", () => {
     test("Create new keys", () => {
@@ -72,29 +82,29 @@ if (import.meta.vitest) {
     test("API", async () => {
       // First find call no data
       const keys = Keys.createNewKeys()
-      const lines = await find(keys.sign_find_token())
+      const lines = await api.find(keys.sign_find_token())
       expect(lines).toEqual([])
 
       // Add couple of messages
-      await set(keys.encrypt("msg1"))
-      await set(keys.encrypt("msg2"))
+      await api.set(keys.encrypt("msg1"))
+      await api.set(keys.encrypt("msg2"))
 
       // Get all messages back
-      const got = await find(keys.sign_find_token())
+      const got = await api.find(keys.sign_find_token())
       const entries = got.map((entry) => keys.decrypt(entry.payload))
       expect(entries.sort()).toEqual(["msg1", "msg2"]) // Sort order of items with the same timestamp is not defined
 
       // Wait a bit, add a message with a new timestamp and ensure filter works
       await wait(2)
-      const msgId = await set(keys.encrypt("msg3"))
+      const msgId = await api.set(keys.encrypt("msg3"))
       await wait(2)
-      await set(keys.encrypt("msg4"))
-      const filtered = await find(keys.sign_find_token(msgId))
+      await api.set(keys.encrypt("msg4"))
+      const filtered = await api.find(keys.sign_find_token(msgId))
       const filteredEntries = filtered.map((entry) => keys.decrypt(entry.payload))
       expect(filteredEntries.sort()).toEqual(["msg4"])
 
       // Delete it all
-      await deleteAccount(keys)
+      await api.deleteAccount(keys)
     })
   })
 }

--- a/client-web/src/app/auth.ts
+++ b/client-web/src/app/auth.ts
@@ -10,8 +10,6 @@ export const loginSucceeded = async (store: Store, keys: Keys): Promise<void> =>
     storage: Storage.newStorage(keys.public_key_hash()),
     views: Views.new(keys),
   }
-  await store.dispatch("data.sync.loadCached", null)
-  return store.dispatch("data.sync.started", null)
 }
 
 export const login = (store: Store, keyString: string): Promise<void> => {

--- a/client-web/src/app/store.test.ts
+++ b/client-web/src/app/store.test.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "vitest"
+import { Events, Store } from "./store"
+import { APIProvider, ServerApi } from "./api"
+import { KeyPrefixes } from "./data"
+
+class TestStore extends Store {
+  gotEvents = new Map()
+
+  constructor(api?: APIProvider) {
+    super(api ?? new ServerApi())
+  }
+
+  override async dispatch<T extends keyof Events>(event: T, eventArgs: Events[T]): Promise<void> {
+    this.gotEvents.set(event, eventArgs)
+    return super.dispatch(event, eventArgs)
+  }
+
+  async dispatchAndExpect<T1 extends keyof Events, T2 extends keyof Events>(
+    event: T1,
+    eventArgs: Events[T1],
+    expectedEvent: T2,
+    expectedEventArgs?: Events[T2]
+  ): Promise<void> {
+    this.gotEvents = new Map()
+    await this.dispatch(event, eventArgs)
+    if (!this.gotEvents.has(expectedEvent)) {
+      // Fail if expected event didn't occur
+      expect([...this.gotEvents.keys()]).toContain(expectedEvent)
+    }
+    if (expectedEventArgs) {
+      // Check for event argument if we check for those
+      expect(this.gotEvents.get(expectedEvent)).toEqual(expectedEventArgs)
+    }
+  }
+}
+
+class OfflineApi implements APIProvider {
+  set() {
+    return Promise.reject()
+  }
+  find() {
+    return Promise.reject()
+  }
+  deleteAccount() {
+    return Promise.reject()
+  }
+}
+
+test("Initialization should set user to not authenticated", async () => {
+  const store = new TestStore()
+  await store.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
+})
+
+test("Registration should automatically login user", async () => {
+  const store1 = new TestStore()
+  await store1.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
+  await store1.dispatchAndExpect(
+    "auth.registration.started",
+    { mode: "automatic" },
+    "auth.login.succeeded"
+  )
+  expect(store1.userState.encryptionPool).toBeTruthy()
+
+  // Next time user should be authenticated automatically
+  const store2 = new TestStore()
+  await store2.dispatchAndExpect("init.started", null, "auth.login.succeeded")
+  expect(store2.userState.encryptionPool).toBeTruthy()
+
+  // But after logout cached credentials are removed
+  await store2.dispatchAndExpect("auth.logout.started", null, "auth.logout.succeeded")
+  const store3 = new TestStore()
+  await store3.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
+})
+
+test("On login fetch entries", async () => {
+  const store1 = new TestStore()
+  await store1.dispatch("init.started", null)
+  await store1.dispatch("auth.registration.started", { mode: "automatic" })
+  await store1.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
+    added: 0,
+    fetched: 0,
+  })
+  // No data by default
+  expect(await store1.userState.storage.itemCount()).toEqual(0)
+
+  // Add few remote entries and on next login remote entries should be added
+  const entry = "2022-06-07 10:00 11:00 foo"
+  await store1.dispatch("data.entry.added", { entry: entry + "1", callSyncAfter: false })
+  await store1.dispatchAndExpect(
+    "data.entry.added",
+    { entry: entry + "2", callSyncAfter: true },
+    "data.sync.succeeded",
+    { added: 2, fetched: 2 }
+  )
+  const store2 = new TestStore()
+  await store2.dispatch("init.started", null)
+  await store2.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
+    added: 0,
+    fetched: 1, // As there are two entries with the same timestamp we see here another one from what we send via lastKnownId
+  })
+  const values = await store1.userState.storage.values(KeyPrefixes.EntryRemote)
+  expect(values.map((v) => v.value).sort()).toEqual([entry + "1", entry + "2"])
+})
+
+test("Status pending when new local entries exists", async () => {
+  const store = new TestStore()
+  await store.dispatch("init.started", null)
+  await store.dispatch("auth.registration.started", { mode: "automatic" })
+  await store.dispatchAndExpect(
+    "data.entry.added",
+    { entry: "2022-06-07 10:00 11:00 foo", callSyncAfter: false },
+    "status.sync",
+    { status: "pending" }
+  )
+  const checkEntries = async (entries: { local: number; remote: number }) => {
+    const storage = store.userState.storage
+    expect(await storage.values(KeyPrefixes.EntryLocal)).toHaveLength(entries.local)
+    expect(await storage.values(KeyPrefixes.EntryRemote)).toHaveLength(entries.remote)
+  }
+  await checkEntries({ local: 1, remote: 0 })
+  await store.dispatchAndExpect("data.sync.started", null, "status.sync", { status: "completed" })
+  await checkEntries({ local: 0, remote: 1 })
+})
+
+test("Status remains pending when sending failed", async () => {
+  const store = new TestStore(new OfflineApi())
+  await store.dispatch("init.started", null)
+  await store.dispatch("auth.registration.started", { mode: "automatic" })
+  await store.dispatchAndExpect(
+    "data.entry.added",
+    { entry: "2022-06-07 10:00 11:00 foo", callSyncAfter: true },
+    "status.sync",
+    { status: "pending" }
+  )
+})

--- a/client-web/src/main.ts
+++ b/client-web/src/main.ts
@@ -6,6 +6,7 @@ import "./ui/pages/login"
 import "./ui/pages/progress"
 import { Store } from "./app/store"
 import { DateDay } from "../bridge/pkg/qqself_client_web_bridge"
+import { ServerApi } from "./app/api"
 
 type Page = "loading" | "login" | "register" | "progress" | "devcards"
 
@@ -14,7 +15,7 @@ export class Main extends LitElement {
   @state()
   page: Page = "loading"
 
-  store = new Store()
+  store = new Store(new ServerApi())
 
   async firstUpdated() {
     if (import.meta.env.DEV) {

--- a/client-web/src/ui/components/statusBar.ts
+++ b/client-web/src/ui/components/statusBar.ts
@@ -1,0 +1,31 @@
+import { css, html, LitElement } from "lit"
+import { customElement, property } from "lit/decorators.js"
+import "../controls/logo"
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "q-status-bar": StatusBar
+  }
+}
+
+@customElement("q-status-bar")
+export class StatusBar extends LitElement {
+  @property()
+  status: "pending" | "completed" = "completed"
+
+  @property()
+  currentOp: string | null = null
+
+  static styles = css`
+    .root {
+      border: 1px solid gray;
+      padding: 0 5px;
+    }
+  `
+
+  render() {
+    const status = this.status == "pending" ? "Sync pending" : "In sync"
+    const op = this.currentOp ? `. ${this.currentOp}` : ""
+    return html`<div class="root">${status}${op}</div>`
+  }
+}

--- a/client-web/src/ui/pages/devcards.ts
+++ b/client-web/src/ui/pages/devcards.ts
@@ -3,8 +3,9 @@ import { customElement, property, state } from "lit/decorators.js"
 import { DateDay } from "../../../bridge/pkg/qqself_client_web_bridge"
 import "../components/skills"
 import "../components/entryInput"
-import "../controls/panel"
 import "../components/journal"
+import "../components/statusBar"
+import "../controls/panel"
 import "../pages/progress"
 import { Store } from "../../app/store"
 import { trace } from "../../logger"
@@ -115,6 +116,14 @@ export class DevcardsPage extends LitElement {
 
       <q-card name="AddEntry - Empty">
         <q-entry-input></q-entry-input>
+      </q-card>
+
+      <q-card name="Status bar - Default">
+        <q-status-bar> </q-status-bar>
+      </q-card>
+
+      <q-card name="Status bar - Pending">
+        <q-status-bar status="pending" currentOp="Fetching data..."> </q-status-bar>
       </q-card>
 
       <!-- Pages -->


### PR DESCRIPTION
- Introduce `APIProvider` interface, so it can be easily mocked during tests, add `OfflineAPI` test implementation 
- Previously `data.sync.started` was dispatched automatically after successful login. UI wasn't ready yet, so sync events were lost. Now first sync starts only after manually dispatched `data.sync.init` event 
- Error handling in sync process didn't worked properly, fixed that and added test to ensure it works
- Add new `StatusBar` UI component which renders current sync status
- Move tests out of `store.ts` to it's separate `store.test.ts` as we have quite a lot of those