### PR TITLE
core Better views update calculation, skills notification logic

### DIFF
--- a/client-cli/src/operations/report.rs
+++ b/client-cli/src/operations/report.rs
@@ -57,12 +57,12 @@ pub fn report(opts: ReportOpts) {
         // Parse the record to see if it's a valid one
         let entry = Entry::parse(&line)
             .unwrap_or_else(|err| panic!("error parsing the line '{line}' - {err}"));
-        db.add(Record::from_entry(entry, 0))
+        db.add(Record::from_entry(entry, 0), false)
     });
     println!("Skills:");
-    for skill in db.skills() {
+    db.skills().iter().for_each(|(_, skill)| {
         println!("{}", skill);
-    }
+    });
 
     let (start, end) = journal_range(opts.period);
     println!("Journal for range: {} - {}", start, end);

--- a/client-web/src/app/auth.ts
+++ b/client-web/src/app/auth.ts
@@ -15,7 +15,7 @@ export const loginSucceeded = async (store: Store, keys: Keys): Promise<void> =>
       //      setTimeout allows callback to complete, freeing `Views &mut self` and
       //      schedules actual callback logic for the next event loop cycle
       setTimeout(() => {
-        const update = Object.fromEntries(argsMap) as ViewUpdate
+        const update = Object.fromEntries(argsMap) as unknown as ViewUpdate
         if (update.view == "Journal") {
           void store.dispatch("views.update.journal", { update })
         } else {

--- a/client-web/src/app/data.ts
+++ b/client-web/src/app/data.ts
@@ -34,11 +34,11 @@ export class DataEvents {
     let loadedRemote = 0
     let loadedLocal = 0
     for (const entry of await storage.values(KeyPrefixes.EntryRemote)) {
-      this.store.userState.views.add_entry(entry.value)
+      this.store.userState.views.add_entry(entry.value, false)
       loadedRemote++
     }
     for (const entry of await storage.values(KeyPrefixes.EntryLocal)) {
-      this.store.userState.views.add_entry(entry.value)
+      this.store.userState.views.add_entry(entry.value, false)
       loadedLocal++
     }
     trace(`DataEvents loaded cached data: remote=${loadedRemote}, local=${loadedLocal}`)
@@ -80,7 +80,7 @@ export class DataEvents {
   }
 
   async onEntryAdded(entry: string, callSyncAfter: boolean): Promise<void> {
-    this.store.userState.views.add_entry(entry)
+    this.store.userState.views.add_entry(entry, true)
     await this.addEntryToCache(entry, null)
     await this.store.dispatch("status.sync", { status: "pending" })
     if (callSyncAfter) {
@@ -134,7 +134,7 @@ export class DataEvents {
     const requestFinished = performance.now()
     const decrypted = await this.store.userState.encryptionPool.decryptAll(remoteEntries)
     for (const entry of decrypted) {
-      this.store.userState.views.add_entry(entry.text)
+      this.store.userState.views.add_entry(entry.text, false)
       await this.addEntryToCache(entry.text, entry.id)
     }
     if (decrypted.length > 1) {

--- a/client-web/src/app/store.test.ts
+++ b/client-web/src/app/store.test.ts
@@ -3,12 +3,12 @@ import { KeyPrefixes } from "./data"
 import { OfflineApi, TestStore } from "../utilsTests"
 
 test("Initialization should set user to not authenticated", async () => {
-  const store = new TestStore()
+  const store = new TestStore(expect)
   await store.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
 })
 
 test("Registration should automatically login user", async () => {
-  const store1 = new TestStore()
+  const store1 = new TestStore(expect)
   await store1.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
   await store1.dispatchAndExpect(
     "auth.registration.started",
@@ -18,18 +18,18 @@ test("Registration should automatically login user", async () => {
   expect(store1.userState.encryptionPool).toBeTruthy()
 
   // Next time user should be authenticated automatically
-  const store2 = new TestStore()
+  const store2 = new TestStore(expect)
   await store2.dispatchAndExpect("init.started", null, "auth.login.succeeded")
   expect(store2.userState.encryptionPool).toBeTruthy()
 
   // But after logout cached credentials are removed
   await store2.dispatchAndExpect("auth.logout.started", null, "auth.logout.succeeded")
-  const store3 = new TestStore()
+  const store3 = new TestStore(expect)
   await store3.dispatchAndExpect("init.started", null, "auth.login.notAuthenticated")
 })
 
 test("On login fetch entries", async () => {
-  const store1 = new TestStore()
+  const store1 = new TestStore(expect)
   await store1.dispatch("init.started", null)
   await store1.dispatch("auth.registration.started", { mode: "automatic" })
   await store1.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
@@ -48,7 +48,7 @@ test("On login fetch entries", async () => {
     "data.sync.succeeded",
     { added: 2, fetched: 2 }
   )
-  const store2 = new TestStore()
+  const store2 = new TestStore(expect)
   await store2.dispatch("init.started", null)
   await store2.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
     added: 0,
@@ -59,7 +59,7 @@ test("On login fetch entries", async () => {
 })
 
 test("Status pending when new local entries exists", async () => {
-  const store = new TestStore()
+  const store = new TestStore(expect)
   await store.dispatch("init.started", null)
   await store.dispatch("auth.registration.started", { mode: "automatic" })
   await store.dispatchAndExpect(
@@ -79,7 +79,7 @@ test("Status pending when new local entries exists", async () => {
 })
 
 test("Status remains pending when sending failed", async () => {
-  const store = new TestStore(new OfflineApi())
+  const store = new TestStore(expect, new OfflineApi())
   await store.dispatch("init.started", null)
   await store.dispatch("auth.registration.started", { mode: "automatic" })
   await store.dispatchAndExpect(

--- a/client-web/src/app/store.ts
+++ b/client-web/src/app/store.ts
@@ -7,16 +7,14 @@ import { DataEvents } from "./data"
 import { debug, info } from "../logger"
 import { APIProvider } from "./api"
 
-// TODO ViewUpdate is a complex nested enum, maybe there is some way to generate TypeScript definition for it from Rust?
 export interface JournalViewUpdate {
   view: "Journal"
-  type: "DayUpdated"
   day: string
 }
-export type SkillsViewUpdate =
-  | { view: "Skills"; type: "HourProgress"; message: string }
-  | { view: "Skills"; type: "LevelUp"; message: string }
-
+export interface SkillsViewUpdate {
+  view: "Skills"
+  message: string
+}
 export type ViewUpdate = JournalViewUpdate | SkillsViewUpdate
 
 // Events are application wide activities that causes some side effect

--- a/client-web/src/main.ts
+++ b/client-web/src/main.ts
@@ -39,7 +39,7 @@ export class Main extends LitElement {
         return html`<q-loading-page .store=${this.store} />`
       case "devcards":
         if (import.meta.env.DEV) {
-          return html`<q-devcards-page .store=${this.store} />`
+          return html`<q-devcards-page />`
         } else {
           throw new Error("Devcards should not be available in production")
         }

--- a/client-web/src/ui/pages/devcards.ts
+++ b/client-web/src/ui/pages/devcards.ts
@@ -10,6 +10,7 @@ import "../pages/progress"
 import { Store } from "../../app/store"
 import { trace } from "../../logger"
 import { EntrySaveEvent } from "../components/entryInput"
+import { OfflineApi, TestStore } from "../../utilsTests"
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -48,8 +49,7 @@ export class Card extends LitElement {
 // Custom page with all UI elements, used mostly for development, kinda like storybooks
 @customElement("q-devcards-page")
 export class DevcardsPage extends LitElement {
-  @property({ type: Object })
-  store!: Store
+  store = new TestStore(new OfflineApi())
 
   @state()
   cards: TemplateResult | null = null

--- a/client-web/src/ui/pages/devcards.ts
+++ b/client-web/src/ui/pages/devcards.ts
@@ -49,7 +49,7 @@ export class Card extends LitElement {
 // Custom page with all UI elements, used mostly for development, kinda like storybooks
 @customElement("q-devcards-page")
 export class DevcardsPage extends LitElement {
-  store = new TestStore(new OfflineApi())
+  store = new TestStore(undefined, new OfflineApi())
 
   @state()
   cards: TemplateResult | null = null

--- a/client-web/src/ui/pages/progress.test.ts
+++ b/client-web/src/ui/pages/progress.test.ts
@@ -1,12 +1,12 @@
 import { html, render } from "lit"
 import { OfflineApi, TestStore } from "../../utilsTests"
-import { describe, test } from "vitest"
+import { describe, test, expect } from "vitest"
 import { DateDay } from "../../../bridge/pkg"
 import "./progress"
 
 describe("progress", () => {
   test("render", async () => {
-    const store = new TestStore(new OfflineApi())
+    const store = new TestStore(expect, new OfflineApi())
     await store.dispatch("init.started", null)
     await store.dispatch("auth.registration.started", { mode: "automatic" })
     render(

--- a/client-web/src/utilsTests.ts
+++ b/client-web/src/utilsTests.ts
@@ -1,6 +1,5 @@
 import { APIProvider, ServerApi } from "./app/api"
 import { Events, Store } from "./app/store"
-import { expect } from "vitest"
 
 export class TestStore extends Store {
   gotEvents = new Map()
@@ -22,6 +21,11 @@ export class TestStore extends Store {
   ): Promise<void> {
     this.gotEvents = new Map()
     await this.dispatch(event, eventArgs)
+    // Dynamically load `expect` as it's sometimes useful to use TestStore outside of testing context.
+    // Importing `vitest` causes errors if imported outside of vitest context
+    const { expect } = await import("vitest")
+    // TODO: Still it gives warning during production build, accept `expect` as a parameter
+
     if (!this.gotEvents.has(expectedEvent)) {
       // Fail if expected event didn't occur
       console.log(this.gotEvents.keys())

--- a/core/src/data_views/skills.rs
+++ b/core/src/data_views/skills.rs
@@ -1,62 +1,410 @@
-use std::collections::btree_map::Iter;
+use std::{
+    collections::{btree_map::Iter, BTreeMap},
+    fmt::Display,
+};
 
 use crate::{
-    date_time::datetime::DateTimeRange,
-    db::{ChangeEvent, Record, RecordValue},
-    progress::skill::Skill,
+    date_time::datetime::{DateDay, DateTimeRange},
+    db::{ChangeEvent, Notification, Record, RecordValue, ViewUpdate},
+    progress::skill::{Skill, SkillProgress},
 };
 
 /// View shows data from perspective of skill development
 #[derive(Default)]
 pub struct SkillsView {
-    data: Vec<Skill>,
+    data: BTreeMap<String, Skill>,
 }
 
-pub enum SkillsUpdate {
+#[derive(PartialEq, Debug)]
+pub struct SkillsUpdate {
+    pub skill: String,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum SkillsNotification {
     LevelUp(String),
     HourProgress(String),
 }
 
 impl SkillsView {
-    pub fn update(&mut self, all: Iter<DateTimeRange, Record>, _: &ChangeEvent) -> Option<SkillsUpdate> {
-        // TODO We can optimize by processing added records instead of recalculating things every time
-        self.recalculate(all)
-    }
-
-    fn recalculate(&mut self, records: Iter<DateTimeRange, Record>) -> Option<SkillsUpdate> {
-        self.data.clear(); // Start over discarding all existing skills
-        for (_, record) in records {
-            let entry = match record {
-                Record::Value(RecordValue::Entry(entry)) => entry.entry(),
-                _ => continue, // We don't care about non entries
-            };
-            // TODO Skill calculation works only if skill definition appears before it's entries
-            match Skill::from_record(entry) {
-                Some(skill) => {
-                    if let Some(existing) =
-                        self.data.iter_mut().find(|v| v.title() == skill.title())
-                    {
-                        existing.merge_selector(skill); // Skill exists, merge it's selectors
-                    } else {
-                        self.data.push(skill); // New skill - add as is
-                    }
+    pub fn update(
+        &mut self,
+        all: Iter<DateTimeRange, Record>,
+        event: &ChangeEvent,
+        interactive: bool,
+        now: Option<DateDay>,
+        on_view_update: &Option<Box<dyn Fn(ViewUpdate)>>,
+        on_notification: &Option<Box<dyn Fn(Notification)>>,
+    ) {
+        let ChangeEvent::Added(Record::Value(RecordValue::Entry(entry))) = event else { return };
+        if let Some(mut skill) = Skill::from_record(entry.entry()) {
+            // If it's a Skill - go back and re-read all previous record to accumulate duration
+            for (_, record) in all.clone() {
+                let Record::Value(RecordValue::Entry(entry)) = record else { continue; };
+                if skill.selector().matches(entry.entry()) {
+                    skill.add_duration(entry.entry().date_range.duration());
                 }
-                None => {
-                    // Normal entry, iterate all the skills and append time if matches
-                    for skill in self.data.iter_mut() {
-                        if skill.selector().matches(entry) {
-                            skill.add_duration(entry.date_range.duration());
-                            continue; // Only append duration once per skill
-                        }
-                    }
+            }
+            self.data.insert(skill.title().to_string(), skill.clone());
+            self.process_update(&skill, on_view_update);
+            self.process_notification(
+                &skill,
+                interactive,
+                on_notification,
+                now,
+                all.clone(),
+                SkillProgress::default(),
+            )
+        } else {
+            // If it's a record - add it to the corresponding Skill if exists
+            for (_, skill) in self.data.iter_mut() {
+                if skill.selector().matches(entry.entry()) {
+                    skill.add_duration(entry.entry().date_range.duration());
+                }
+            }
+            // Second iteration to notify about skills progress
+            for (_, skill) in self.data.iter() {
+                if skill.selector().matches(entry.entry()) {
+                    self.process_update(skill, on_view_update);
+                    self.process_notification(
+                        skill,
+                        interactive,
+                        on_notification,
+                        now,
+                        all.clone(),
+                        SkillProgress::new(
+                            skill.progress().duration_minutes
+                                - entry.entry().date_range().duration().minutes(),
+                        ),
+                    )
                 }
             }
         }
-        self.data.sort(); // Keep skills sorted
-        None
     }
 
-    pub fn data(&self) -> &Vec<Skill> {
+    pub fn data(&self) -> &BTreeMap<String, Skill> {
+        // TODO Now Skills are sorted by it's Title, it should be sorted by our custom logic, see `Skill::Ord`
         &self.data
+    }
+
+    fn process_update(&self, skill: &Skill, on_view_update: &Option<Box<dyn Fn(ViewUpdate)>>) {
+        if let Some(on_view_update) = on_view_update {
+            // Emit event that view got updated
+            on_view_update(ViewUpdate::Skills(SkillsUpdate {
+                skill: skill.title().to_string(),
+            }))
+        }
+    }
+
+    fn process_notification(
+        &self,
+        skill: &Skill,
+        interactive: bool,
+        on_notification: &Option<Box<dyn Fn(Notification)>>,
+        now: Option<DateDay>,
+        all: Iter<DateTimeRange, Record>,
+        progress_before: SkillProgress,
+    ) {
+        let (on_notification, now) = match (interactive, on_notification, now) {
+            (true, Some(on_notification), Some(now)) => (on_notification, now),
+            _ => return,
+        };
+
+        // Skill level got increased
+        let progress_now = skill.progress();
+        if progress_before.level < progress_now.level {
+            on_notification(Notification::Skills(SkillsNotification::LevelUp(format!(
+                "{} level increased to {}",
+                skill.title(),
+                progress_now.level
+            ))))
+        }
+
+        // Accumulate time
+        // ------------------------------------------------------------------|
+        // | Type                | Period   | Checkpoints                    |
+        // ------------------------------------------------------------------|
+        // | All skills combined | Lifetime | Every 500h                     |
+        // | All skills combined | Year     | Every 100h                     |
+        // | All skills combined | Month    | Every 50h                      |
+        // | All skills combined | Week     | Every 20h                      |
+        // | Per skill           | Lifetime | Every 100h                     |
+        // | Per skill           | Year     | Every 50h                      |
+        // | Per skill           | Month    | Every 10h                      |
+        // | Per skill           | Week     | 1h, 3h, 5h, then every 5 hours |
+        // ------------------------------------------------------------------|
+        let mut checkpoints_total = vec![
+            Checkpoint::by_total_time(now, Period::Lifetime, &[], 500),
+            Checkpoint::by_total_time(now, Period::Year, &[], 100),
+            Checkpoint::by_total_time(now, Period::Month, &[], 50),
+            Checkpoint::by_total_time(now, Period::Week, &[], 20),
+        ];
+        let mut checkpoints_skills = vec![
+            Checkpoint::by_skill(now, Period::Lifetime, &[], 100, skill.title().to_string()),
+            Checkpoint::by_skill(now, Period::Year, &[], 50, skill.title().to_string()),
+            Checkpoint::by_skill(now, Period::Month, &[], 10, skill.title().to_string()),
+            Checkpoint::by_skill(now, Period::Week, &[1, 3, 5], 5, skill.title().to_string()),
+        ];
+        for (_, rec) in all {
+            let Record::Value(RecordValue::Entry(entry)) = rec else { continue; };
+            for checkpoint in checkpoints_total.iter_mut() {
+                // If entry belongs to any skill
+                for (_, skill) in self.data.iter() {
+                    if skill.selector().matches(entry.entry()) {
+                        checkpoint.add(entry.entry().date_range)
+                    }
+                }
+            }
+            if skill.selector().matches(entry.entry()) {
+                for checkpoint in checkpoints_skills.iter_mut() {
+                    checkpoint.add(entry.entry().date_range)
+                }
+            }
+        }
+        for checkpoint in checkpoints_total.iter().chain(checkpoints_skills.iter()) {
+            checkpoint.notify_if_needed(progress_before.duration_minutes as usize, on_notification)
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Period {
+    Lifetime,
+    Year,
+    Month,
+    Week,
+}
+
+impl Display for Period {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Period::Lifetime => "",
+            Period::Year => "this year",
+            Period::Month => "this month",
+            Period::Week => "this week",
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Checkpoint {
+    min_date: DateDay,
+    skill: Option<String>,
+    checkpoints_start: &'static [usize],
+    period: Period,
+    checkpoints_every: usize,
+    duration: usize,
+}
+
+impl Checkpoint {
+    fn new(
+        now: DateDay,
+        skill: Option<String>,
+        period: Period,
+        checkpoints_start: &'static [usize],
+        checkpoints_every: usize,
+    ) -> Self {
+        let min_date = match period {
+            Period::Lifetime => DateDay::new(1, 1, 1),
+            Period::Year => now.as_start_of_year(),
+            Period::Month => now.as_start_of_month(),
+            Period::Week => now.as_start_of_week(),
+        };
+        Self {
+            min_date,
+            checkpoints_start,
+            checkpoints_every,
+            period,
+            skill,
+            duration: 0,
+        }
+    }
+
+    fn by_total_time(
+        now: DateDay,
+        period: Period,
+        checkpoints_start: &'static [usize],
+        checkpoints_every: usize,
+    ) -> Self {
+        Checkpoint::new(now, None, period, checkpoints_start, checkpoints_every)
+    }
+
+    fn by_skill(
+        now: DateDay,
+        period: Period,
+        checkpoints_start: &'static [usize],
+        checkpoints_every: usize,
+        skill: String,
+    ) -> Self {
+        Checkpoint::new(
+            now,
+            Some(skill),
+            period,
+            checkpoints_start,
+            checkpoints_every,
+        )
+    }
+
+    fn add(&mut self, date_range: DateTimeRange) {
+        if date_range.start().date() >= self.min_date {
+            self.duration += date_range.duration().minutes() as usize
+        }
+    }
+
+    fn notify_if_needed(&self, duration_before: usize, on_notification: &dyn Fn(Notification)) {
+        let notify = |hours| {
+            let msg = match &self.skill {
+                Some(skill) => format!(
+                    "Great job - you've practiced {} hours of {} {}",
+                    hours, skill, self.period
+                ),
+                None => format!(
+                    "Great job - across all skills you've practiced {} hours {}",
+                    hours, self.period
+                ),
+            };
+            on_notification(Notification::Skills(SkillsNotification::HourProgress(msg)));
+        };
+
+        // We've processed all events and already added an entry_duration, starting point is without it
+        let hours_now = self.duration / 60;
+        let hours_before = duration_before / 60;
+
+        if hours_before != hours_now {
+            for checkpoint in self.checkpoints_start {
+                if hours_now == *checkpoint {
+                    notify(hours_now);
+                    return; // Ignore checkpoint periods if we matched on checkpoint starts to avoid duplicate notifications
+                }
+            }
+        }
+        let periods_before = duration_before / 60 / self.checkpoints_every;
+        let periods_now = self.duration / 60 / self.checkpoints_every;
+        if periods_before != periods_now {
+            notify(periods_now * self.checkpoints_every);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{db::RecordEntry, record::Entry};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct TestSkillView {
+        entries: BTreeMap<DateTimeRange, Record>,
+        skill_view: SkillsView,
+    }
+
+    impl TestSkillView {
+        fn check_notification(
+            &mut self,
+            entry: &str,
+            now: Option<DateDay>,
+        ) -> Vec<SkillsNotification> {
+            let record = Record::Value(RecordValue::Entry(RecordEntry::new(
+                1,
+                Entry::parse(entry).unwrap(),
+            )));
+            self.entries.insert(record.daterange(), record.clone());
+            let called = Rc::new(RefCell::new(Vec::new()));
+            let called_clone = called.clone();
+            self.skill_view.update(
+                self.entries.iter(),
+                &ChangeEvent::Added(record),
+                true,
+                now,
+                &None,
+                &Some(Box::new(move |got| {
+                    match got {
+                        Notification::Skills(update) => {
+                            let mut foo = called_clone.borrow_mut();
+                            foo.push(update);
+                        }
+                    };
+                })),
+            );
+            called.take()
+        }
+    }
+
+    #[test]
+    fn progress_level_up() {
+        let mut view = TestSkillView::default();
+        let now = Some(DateDay::new(2022, 6, 6));
+
+        // No skill attached for the entity
+        assert_eq!(
+            view.check_notification("2022-06-06 10:00 12:00 run", now),
+            vec![]
+        );
+
+        // Adding skill afterwards recalculates all previously added entities
+        assert_eq!(
+            view.check_notification("2022-06-06 13:00 13:00 run. skill kind=sport. Running", now),
+            vec![SkillsNotification::LevelUp(
+                "Running level increased to 2".to_string()
+            )]
+        );
+
+        // Adding not enough for level up
+        assert_eq!(
+            view.check_notification("2022-06-06 14:00 14:05 run", now),
+            vec![]
+        );
+
+        // Adding more to cause another level up
+        assert_eq!(
+            view.check_notification("2022-06-06 15:00 17:00 run", now),
+            vec![SkillsNotification::LevelUp(
+                "Running level increased to 4".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn progress_hours_total() {
+        let mut view = TestSkillView::default();
+        let now = Some(DateDay::new(2022, 6, 8));
+
+        // Total time is ignored for non skill entries
+        assert_eq!(
+            view.check_notification("2022-06-08 00:00 23:00 foo", now),
+            vec![]
+        );
+
+        // Total time in a week
+        view.check_notification("2022-06-08 00:00 00:00 bar1. skill kind=sport. Bar1", now);
+        view.check_notification("2022-06-08 00:00 00:00 bar2. skill kind=sport. Bar2", now);
+        assert_eq!(
+            view.check_notification("2022-06-08 00:00 19:00 bar1", now),
+            vec![
+                SkillsNotification::LevelUp("Bar1 level increased to 13".to_string()),
+                SkillsNotification::HourProgress(
+                    "Great job - you've practiced 10 hours of Bar1 this month".to_string()
+                ),
+                SkillsNotification::HourProgress(
+                    "Great job - you've practiced 15 hours of Bar1 this week".to_string()
+                )
+            ]
+        );
+
+        // Another skill
+        assert_eq!(
+            view.check_notification("2022-06-08 00:00 05:00 bar2", now),
+            vec![
+                SkillsNotification::LevelUp("Bar2 level increased to 5".to_string()),
+                SkillsNotification::HourProgress(
+                    "Great job - across all skills you've practiced 20 hours this week".to_string()
+                ),
+                SkillsNotification::HourProgress(
+                    "Great job - you've practiced 5 hours of Bar2 this week".to_string()
+                ),
+            ]
+        );
     }
 }

--- a/core/src/date_time/datetime.rs
+++ b/core/src/date_time/datetime.rs
@@ -180,6 +180,24 @@ impl DateDay {
     pub fn day(&self) -> usize {
         self.0.day() as usize
     }
+    pub fn days_from_monday(&self) -> u8 {
+        self.0.weekday().number_days_from_monday()
+    }
+    pub fn as_start_of_week(&self) -> Self {
+        self.remove_days(self.days_from_monday().into())
+    }
+    pub fn as_start_of_month(&self) -> Self {
+        self.remove_days(self.day() - 1)
+    }
+    pub fn as_start_of_year(&self) -> Self {
+        DateDay::new(
+            self.year()
+                .try_into()
+                .expect("Cannot get a year from DateDay"),
+            1,
+            1,
+        )
+    }
 }
 
 impl Display for DateDay {
@@ -336,12 +354,14 @@ mod tests {
     use super::*;
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetime_format() {
         let datetime = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 49));
         assert_eq!(datetime.to_string(), "2022-11-23 12:49")
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetime_parse() {
         assert_eq!(
             "2022-11-23 12:49".parse::<DateTime>().unwrap(),
@@ -350,6 +370,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetime_compare() {
         let datetime = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 49));
         let datetime_time = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 50));
@@ -360,17 +381,37 @@ mod tests {
 
     #[cfg(feature = "wasm")]
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn date_now() {
+    fn datetime_now() {
         let date = DateTime::now();
         assert_eq!(date.to_string().len(), 16);
     }
 
     #[test]
-    fn date_format() {
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn dateday_format() {
         assert_eq!(DateDay::new(2022, 5, 9).to_string(), "2022-05-09")
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn dateday_day_of_week() {
+        let day = DateDay::new(2023, 7, 6);
+        assert_eq!(day.days_from_monday(), 3); // Thursday is 3 days from Monday
+        assert_eq!(day.remove_days(3).days_from_monday(), 0); // Finding beginning of the week - Monday
+        assert_eq!(day.add_days(3).days_from_monday(), 6); // Finding end of the week - Sunday
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn dateday_as_start() {
+        let day = DateDay::new(2023, 7, 6);
+        assert_eq!(day.as_start_of_week(), DateDay::new(2023, 7, 3));
+        assert_eq!(day.as_start_of_month(), DateDay::new(2023, 7, 1));
+        assert_eq!(day.as_start_of_year(), DateDay::new(2023, 1, 1));
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn date_parse() {
         assert_eq!(
             "2022-05-09".parse::<DateDay>().unwrap(),
@@ -392,6 +433,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn date_compare() {
         let date = DateDay::new(2022, 5, 5);
         assert!(date < DateDay::new(2022, 5, 6));
@@ -400,11 +442,13 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn time_display() {
         assert_eq!(Time::new(1, 1).to_string(), "01:01");
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn time_parse() {
         assert_eq!("01:01".parse::<Time>().unwrap(), Time::new(1, 1));
         assert_eq!("23:59".parse::<Time>().unwrap(), Time::new(23, 59));
@@ -413,6 +457,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn time_compare() {
         let time = Time::new(10, 10);
         assert!(time < Time::new(10, 11));
@@ -420,6 +465,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetimerange_parse_short() {
         let got = "2022-11-23 12:49 18:32".parse::<DateTimeRange>().unwrap();
         assert_eq!(
@@ -433,6 +479,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetimerange_parse_long() {
         let got = "2022-11-23 12:49 - 2022-11-24 18:32"
             .parse::<DateTimeRange>()
@@ -448,6 +495,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetimerange_format_long() {
         // Long notation
         let start = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 49));
@@ -457,6 +505,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetimerange_format_short() {
         let start = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 49));
         let end = start;
@@ -465,6 +514,7 @@ mod tests {
     }
 
     #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
     fn datetimerange_duration() {
         let from = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 49));
         let to = DateTime::new(DateDay::new(2022, 11, 23), Time::new(12, 55));

--- a/core/src/progress/skill.rs
+++ b/core/src/progress/skill.rs
@@ -16,7 +16,7 @@ Skill examples: Running, Drums, Programming, Sculpture, etc.
 */
 
 /// Skill represents progression of certain activity
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Skill {
     selector: Selector,
     kind: String,
@@ -24,9 +24,22 @@ pub struct Skill {
     duration_minutes: u64,
 }
 
+#[derive(Default, Debug)]
 pub struct SkillProgress {
     pub level: u64,
     pub minutes_till_next: u64,
+    pub duration_minutes: u64,
+}
+
+impl SkillProgress {
+    pub fn new(duration_minutes: u64) -> Self {
+        let (level, minutes_till_next) = skill_level(duration_minutes);
+        SkillProgress {
+            level,
+            minutes_till_next,
+            duration_minutes,
+        }
+    }
 }
 
 impl Skill {
@@ -58,11 +71,7 @@ impl Skill {
 
     /// Returns skill progress - current level and minutes till the next level
     pub fn progress(&self) -> SkillProgress {
-        let (level, minutes_till_next) = skill_level(self.duration_minutes);
-        SkillProgress {
-            level,
-            minutes_till_next,
-        }
+        SkillProgress::new(self.duration_minutes)
     }
 
     pub fn selector(&self) -> &Selector {


### PR DESCRIPTION
- Views previously emitted updated for client re-rendering. Now it may also emit `Notification` in case of interactive mode to  inform user about noticeable progress
- `core::Db` allow specify if `Record` is added in interactive mode. In this case views may emit additional notifications
- Now `JournalView` and `SkillsView` both handles appending new records in a right way, without recalculation of a while view every time
- `SkillsView` has comprehensive logic for skill progress notification 
- `DateDay` now understands day of the week and has a few helpers around it
