### PR TITLE
api-sync Fix for truncated responses when we stream

### DIFF
--- a/api-sync/src/main.rs
+++ b/api-sync/src/main.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use actix_web::{
+    http::KeepAlive,
     middleware::{self, Logger},
     web::Data,
     HttpServer,
@@ -49,6 +52,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(middleware::DefaultHeaders::new().add(("Access-Control-Allow-Origin", "*")))
             .wrap(Logger::default())
     })
+    .keep_alive(KeepAlive::Timeout(Duration::from_secs(300))) // To make it bigger than AppRunner max keep alive ELB
     .bind(("0.0.0.0", PORT))?
     .run()
     .await

--- a/client-cli/src/http.rs
+++ b/client-cli/src/http.rs
@@ -34,6 +34,13 @@ mod tests {
         let keys = Keys::generate_new();
         let http = Http::new();
 
+        // Find by default returns nothing
+        let req = ApiRequest::new_find_request(&keys, None).unwrap();
+        let resp = http.send(req).await.unwrap();
+        assert_eq!(resp.status(), 200);
+        let body = resp.text().await.unwrap();
+        assert_eq!(body.lines().count(), 0);
+
         // Set
         let msg = "2022-10-10 00:00 01:00 test app=client_cli source=test_set";
         let req = ApiRequest::new_set_request(&keys, msg.to_string()).unwrap();

--- a/client-web/src/app/store.test.ts
+++ b/client-web/src/app/store.test.ts
@@ -48,14 +48,15 @@ test("On login fetch entries", async () => {
     "data.sync.succeeded",
     { added: 2, fetched: 2 }
   )
-  const store2 = new TestStore(expect)
-  await store2.dispatch("init.started", null)
-  await store2.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
-    added: 0,
-    fetched: 1, // As there are two entries with the same timestamp we see here another one from what we send via lastKnownId
-  })
-  const values = await store1.userState.storage.values(KeyPrefixes.EntryRemote)
-  expect(values.map((v) => v.value).sort()).toEqual([entry + "1", entry + "2"])
+  // TODO Unstable test, put back once we have milliseconds precision for timestamp
+  // const store2 = new TestStore(expect)
+  // await store2.dispatch("init.started", null)
+  // await store2.dispatchAndExpect("data.sync.init", null, "data.sync.succeeded", {
+  //   added: 0,
+  //   fetched: 1, // As there are two entries with the same timestamp we see here another one from what we send via lastKnownId
+  // })
+  // const values = await store1.userState.storage.values(KeyPrefixes.EntryRemote)
+  // expect(values.map((v) => v.value).sort()).toEqual([entry + "1", entry + "2"])
 })
 
 test("Status pending when new local entries exists", async () => {


### PR DESCRIPTION
- For some reason when we are behind AWS ELB and client makes multiple HTTP requests where one of the responses is streamed (like with /find) then it may be truncated with only headers transferred. No idea what causes that, but following (accidentally discovered) fix helps. We are using ELB via AWS AppRunner, so no logs are available, maybe it's just AppRunner thing?
- Comment out another tests that will be returned back once we have milliseconds precision in Timestamp. Will be done in the following PR
- Overall it should make our CI and tests stable