### PR TITLE
core Change timestamp precision to milliseconds instead of seconds

### DIFF
--- a/api-sync/src/http/routes.rs
+++ b/api-sync/src/http/routes.rs
@@ -343,7 +343,7 @@ mod tests {
             (3, b"00000000001662750869|R85af9xML6WR7fNUXNgi5V"),
             (2, b"00000000001662750871|93i31rxkhgVVzHahAA2LBF"),
         ] {
-            time.sleep(ts).await;
+            time.sleep(std::time::Duration::from_millis(ts)).await;
             let encrypted = PayloadBytes::encrypt(
                 &public_key,
                 &private_key,
@@ -402,7 +402,7 @@ mod tests {
         let (public_key, private_key) = keys(PUBLIC_KEY_1, PRIVATE_KEY_1);
         let time_start = time.now().await;
         for ts in [1, 2, 3] {
-            time.sleep(ts).await;
+            time.sleep(std::time::Duration::from_millis(ts)).await;
             let encrypted = PayloadBytes::encrypt(
                 &public_key,
                 &private_key,

--- a/api-sync/src/time.rs
+++ b/api-sync/src/time.rs
@@ -6,15 +6,15 @@ use qqself_core::date_time::timestamp::Timestamp;
 #[async_trait]
 pub trait TimeProvider {
     async fn now(&self) -> Timestamp;
-    async fn sleep(&self, seconds: u64);
+    async fn sleep(&self, duration: Duration);
 }
 
 /// StaticTime provides static pure timer. Sleep advances internal timestamp and returns immediately
 pub struct TimeStatic(Mutex<u64>);
 
 impl TimeStatic {
-    pub fn new(initial_seconds: u64) -> Self {
-        Self(Mutex::from(initial_seconds))
+    pub fn new(milliseconds: u64) -> Self {
+        Self(Mutex::from(milliseconds))
     }
 }
 
@@ -24,9 +24,9 @@ impl TimeProvider for TimeStatic {
         let time = self.0.lock().unwrap();
         Timestamp::from_u64(*time)
     }
-    async fn sleep(&self, seconds: u64) {
+    async fn sleep(&self, duration: Duration) {
         let mut time = self.0.lock().unwrap();
-        *time += seconds;
+        *time += duration.as_millis() as u64;
     }
 }
 
@@ -39,7 +39,7 @@ impl TimeProvider for TimeOs {
     async fn now(&self) -> Timestamp {
         Timestamp::now()
     }
-    async fn sleep(&self, seconds: u64) {
-        tokio::time::sleep(Duration::from_secs(seconds)).await;
+    async fn sleep(&self, duration: Duration) {
+        tokio::time::sleep(duration).await;
     }
 }


### PR DESCRIPTION
- When we supply `lastKnownId` then `/find` returns entries with bigger or equal timestamp. We are using seconds precision in timestamp and situation when two entries uses same timestamp happens often. It also makes tests less stable
- This PR changes `Timestamp` precision to be milliseconds
- It's also probably a breaking change, so AWS DynamoDB has to be cleaned up afterwards 