### PR TITLE
client-cli Rename export to upload, sort entries in JournalDay

### DIFF
--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -1,5 +1,5 @@
 use operations::{
-    export::{export, ExportOpts},
+    upload::{upload, UploadOpts},
     init::{init, InitOpts},
     report::{report, ReportOpts},
 };
@@ -13,7 +13,7 @@ mod operations;
 #[derive(StructOpt, Debug)]
 enum Opts {
     Init(InitOpts),
-    Export(ExportOpts),
+    Upload(UploadOpts),
     Report(ReportOpts),
 }
 
@@ -30,7 +30,7 @@ fn main() {
         .init();
     match Opts::from_args() {
         Opts::Init(opts) => init(opts),
-        Opts::Export(opts) => export(opts),
+        Opts::Upload(opts) => upload(opts),
         Opts::Report(opts) => report(opts),
     }
 }

--- a/client-cli/src/operations/mod.rs
+++ b/client-cli/src/operations/mod.rs
@@ -1,3 +1,3 @@
-pub mod export;
+pub mod upload;
 pub mod init;
 pub mod report;

--- a/core/src/data_views/journal.rs
+++ b/core/src/data_views/journal.rs
@@ -1,14 +1,14 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    date_time::datetime::{DateDay},
+    date_time::datetime::DateDay,
     db::{ChangeEvent, Record, RecordValue, ViewUpdate},
     record::Entry,
 };
 
 #[derive(Clone, Debug)]
 pub struct JournalDay {
-    pub entries: Vec<Entry>,
+    pub entries: BTreeSet<Entry>,
     pub day: DateDay,
 }
 
@@ -16,7 +16,7 @@ impl JournalDay {
     pub fn new(day: DateDay) -> Self {
         Self {
             day,
-            entries: vec![],
+            entries: BTreeSet::default(),
         }
     }
 }
@@ -41,9 +41,9 @@ impl JournalView {
         let entry_day = entry.entry().date_range().start().date();
         let journal_day = self.data.entry(entry_day).or_insert(JournalDay {
             day: entry_day,
-            entries: vec![],
+            entries: BTreeSet::default(),
         });
-        journal_day.entries.push(entry.entry().clone());
+        journal_day.entries.insert(entry.entry().clone());
         if let Some(update) = on_view_update {
             update(ViewUpdate::Journal(JournalUpdate { day: entry_day }));
         }


### PR DESCRIPTION
- Rename `export` to `upload` in client-cli as it was confusing - export from server to the client, export from client to the server? With upload it's clear
- Noticed that entries in JournalDay are not sorted and returned by order they were inserted to API rather than entry DataRange