### PR TITLE
core Add query support

### DIFF
--- a/client-cli/src/operations/report.rs
+++ b/client-cli/src/operations/report.rs
@@ -56,7 +56,7 @@ pub fn report(opts: ReportOpts) {
         // Parse the record to see if it's a valid one
         let entry = Entry::parse(&line)
             .unwrap_or_else(|err| panic!("error parsing the line '{line}' - {err}"));
-        db.add(Record::from_entry(entry, 0), false, None)
+        db.add(Record::from_entry(entry, 0), false, None);
     });
     println!("Skills:");
     db.skills().iter().for_each(|(_, skill)| {


### PR DESCRIPTION
- Remove obsolete `DBSubscriber` from the `core::DB`
- Implement previously missing `core::DB::query`
- `core::DB::Query` now can parse additional filter tag like `filter date > 2023-05-03` and uses that for entry date range filtering
- `Tokenizer` now supports all three `=,<,>` property operators