### PR TITLE
client-web Edit button for the entries

### DIFF
--- a/client-web/.eslintrc.cjs
+++ b/client-web/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
     project: true,
     tsconfigRootDir: __dirname,
   },
-  plugins: ["@typescript-eslint", "unused-imports"],
+  plugins: ["@typescript-eslint", "unused-imports", "simple-import-sort"],
   root: true,
   globals: {
     fetch: "readonly",
@@ -19,5 +19,7 @@ module.exports = {
   rules: {
     "no-redeclare": ["error", { builtinGlobals: false }],
     "unused-imports/no-unused-imports": "error",
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
   },
 }

--- a/client-web/package.json
+++ b/client-web/package.json
@@ -6,8 +6,8 @@
     "build:bridge": "wasm-pack build bridge --out-dir pkg --target web --release",
     "build": "yarn build:bridge && tsc --noEmit && vite build",
     "test": "wasm-pack build bridge --out-dir pkg --target nodejs --release && VITE_API_HOST=https://api.qqself.com vitest --run --test-timeout 10000",
-    "lint:fix": "yarn build:bridge && prettier --write 'src/**/*.ts' && eslint 'src/**/*.ts' --fix && lit-analyzer --strict src",
-    "lint:check": "yarn build:bridge && prettier --check 'src/**/*.ts' && eslint 'src/**/*.ts' && lit-analyzer --strict src"
+    "lint:fix": "yarn build:bridge && eslint 'src/**/*.ts' --fix && prettier --write 'src/**/*.ts' && lit-analyzer --strict src",
+    "lint:check": "yarn build:bridge && eslint 'src/**/*.ts' && prettier --check 'src/**/*.ts' && lit-analyzer --strict src"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.4.0",
@@ -17,14 +17,15 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
-    "eslint": "8.46.0",
+    "eslint-plugin-simple-import-sort": "10.0.0",
     "eslint-plugin-unused-imports": "3.0.0",
+    "eslint": "8.46.0",
     "jsdom": "22.1.0",
     "lit-analyzer": "2.0.0-pre.3",
     "prettier": "3.0.0",
     "typescript": "5.1.6",
-    "vite": "4.4.8",
     "vite-plugin-rsw": "2.0.11",
+    "vite": "4.4.8",
     "vitest": "0.34.1",
     "wasm-pack": "0.12.1"
   }

--- a/client-web/src/app/auth.ts
+++ b/client-web/src/app/auth.ts
@@ -1,7 +1,7 @@
-import { Views, Keys } from "../../bridge/pkg/qqself_client_web_bridge"
+import { Keys, Views } from "../../bridge/pkg/qqself_client_web_bridge"
 import { EncryptionPool } from "./encryptionPool/pool"
-import { Store, ViewNotification, ViewUpdate } from "./store"
 import * as Storage from "./storage/storage"
+import { Store, ViewNotification, ViewUpdate } from "./store"
 
 export const loginSucceeded = async (store: Store, keys: Keys): Promise<void> => {
   await saveCredentials(keys)

--- a/client-web/src/app/data.ts
+++ b/client-web/src/app/data.ts
@@ -1,8 +1,8 @@
+import { DateDay, stringHash } from "../../bridge/pkg"
+import { APIProvider } from "../app/api"
 import { trace } from "../logger"
 import { isBrowser } from "../utils"
 import { Store } from "./store"
-import { DateDay, stringHash } from "../../bridge/pkg"
-import { APIProvider } from "../app/api"
 
 // We have one KV storage, to differentiate values we are using different prefixes for the keys
 export const KeyPrefixes = {

--- a/client-web/src/app/encryptionPool/pool.ts
+++ b/client-web/src/app/encryptionPool/pool.ts
@@ -1,9 +1,9 @@
 import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
-import { EncryptedEntry } from "../api"
-import { InputType, SignInput, WorkerResult } from "./worker"
 import { info } from "../../logger"
-import { ThreadWorker } from "./thread-worker"
 import { isBrowser } from "../../utils"
+import { EncryptedEntry } from "../api"
+import { ThreadWorker } from "./thread-worker"
+import { InputType, SignInput, WorkerResult } from "./worker"
 
 export interface DecryptedEntry {
   id: string

--- a/client-web/src/app/encryptionPool/thread-worker.ts
+++ b/client-web/src/app/encryptionPool/thread-worker.ts
@@ -1,5 +1,5 @@
 import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
-import { InputType, OutputType, WorkerResult, processMessage } from "./worker"
+import { InputType, OutputType, processMessage, WorkerResult } from "./worker"
 
 // Right way is to go with node:worker_threads, but unfortunately
 // building it is challenging in Vite: https://github.com/vitejs/vite/pull/3932

--- a/client-web/src/app/encryptionPool/web-worker.ts
+++ b/client-web/src/app/encryptionPool/web-worker.ts
@@ -1,4 +1,4 @@
-import init, { Keys, initialize } from "../../../bridge/pkg/qqself_client_web_bridge"
+import init, { initialize, Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
 import { InputType, OutputType, processMessage } from "./worker"
 
 let cachedKeys: Keys | null = null

--- a/client-web/src/app/init.ts
+++ b/client-web/src/app/init.ts
@@ -1,8 +1,8 @@
 import init, { initialize, Keys } from "../../bridge/pkg/qqself_client_web_bridge"
-import { Store } from "./store"
+import { info } from "../logger"
 import { isBrowser } from "../utils"
 import { getCredentials } from "./auth"
-import { info } from "../logger"
+import { Store } from "./store"
 
 export const started = async (store: Store): Promise<void> => {
   const apiCheckError = checkMissingAPI()

--- a/client-web/src/app/storage/indexeddb.ts
+++ b/client-web/src/app/storage/indexeddb.ts
@@ -1,4 +1,5 @@
 import localforage from "localforage"
+
 import { Storage } from "./storage"
 
 export class IndexedDbStorage implements Storage {

--- a/client-web/src/app/store.test.ts
+++ b/client-web/src/app/store.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest"
-import { KeyPrefixes } from "./data"
+
 import { OfflineApi, TestStore } from "../utilsTests"
+import { KeyPrefixes } from "./data"
 
 test("Initialization should set user to not authenticated", async () => {
   const store = new TestStore(expect)

--- a/client-web/src/app/store.ts
+++ b/client-web/src/app/store.ts
@@ -1,11 +1,11 @@
 import { Keys, Views } from "../../bridge/pkg/qqself_client_web_bridge"
-import { EncryptionPool } from "./encryptionPool/pool"
-import { Storage } from "./storage/storage"
-import * as Auth from "./auth"
-import * as Init from "./init"
-import { DataEvents } from "./data"
 import { debug, info } from "../logger"
 import { APIProvider } from "./api"
+import * as Auth from "./auth"
+import { DataEvents } from "./data"
+import { EncryptionPool } from "./encryptionPool/pool"
+import * as Init from "./init"
+import { Storage } from "./storage/storage"
 
 export interface QueryResultsUpdate {
   view: "QueryResults"

--- a/client-web/src/main.ts
+++ b/client-web/src/main.ts
@@ -1,12 +1,14 @@
-import { css, html, LitElement } from "lit"
-import { customElement, state } from "lit/decorators.js"
 import "./ui/pages/loading"
 import "./ui/pages/register"
 import "./ui/pages/login"
 import "./ui/pages/progress"
-import { Store } from "./app/store"
+
+import { css, html, LitElement } from "lit"
+import { customElement, state } from "lit/decorators.js"
+
 import { DateDay } from "../bridge/pkg/qqself_client_web_bridge"
 import { ServerApi } from "./app/api"
+import { Store } from "./app/store"
 import { colors } from "./ui/styles"
 
 type Page = "loading" | "login" | "register" | "progress" | "devcards"

--- a/client-web/src/ui/components/entryInput.ts
+++ b/client-web/src/ui/components/entryInput.ts
@@ -1,9 +1,12 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property, state } from "lit/decorators.js"
-import { validateEntry } from "../../../bridge/pkg"
 import "../controls/logo"
 
+import { css, html, LitElement } from "lit"
+import { customElement, property } from "lit/decorators.js"
+
+import { validateEntry } from "../../../bridge/pkg"
+
 export type EntrySaveEvent = CustomEvent<{ entry: string }>
+export type EntryUpdateEvent = CustomEvent<{ entry: string }>
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -16,58 +19,51 @@ export class EntryInput extends LitElement {
   @property()
   entry = ""
 
-  @state()
-  currentEntry = ""
-
-  @state()
-  isEntryValid = false
-
-  @state()
-  validationError: string | undefined = ""
-
   static styles = css`
-    .root input {
-      width: 300px;
+    .root .input {
+      display: flex;
+      justify-content: space-evenly;
+    }
+    .root .input .text {
+      width: 100%;
+      margin-right: 10px;
     }
     .root .error {
       color: red;
     }
   `
 
-  firstUpdated() {
-    this.currentEntry = this.entry
-    this.validateEntry()
-  }
-
   onSave() {
     const event: EntrySaveEvent = new CustomEvent("save", {
       detail: {
-        entry: this.currentEntry,
+        entry: this.entry,
       },
     })
     this.dispatchEvent(event)
-
-    this.currentEntry = ""
-    this.validateEntry()
+    this.entry = ""
   }
 
   entryUpdated(event: InputEvent) {
-    this.currentEntry = (event.target as HTMLInputElement).value
-    this.validateEntry()
-  }
-
-  validateEntry() {
-    this.validationError = validateEntry(this.currentEntry)
-    this.isEntryValid = this.validationError == undefined
+    this.entry = (event.target as HTMLInputElement).value
+    const updateEvent: EntryUpdateEvent = new CustomEvent("update", {
+      detail: {
+        entry: this.entry,
+      },
+    })
+    this.dispatchEvent(updateEvent)
   }
 
   render() {
+    const validationError = validateEntry(this.entry)
+    const isEntryValid = validationError == undefined
     return html`<div class="root">
-      <input type="text" .value="${this.currentEntry}" @input=${this.entryUpdated.bind(
-        this,
-      )}></input>
-      <button ?disabled=${!this.isEntryValid} @click="${this.onSave.bind(this)}">Save</button>  
-      <div class="error">${this.validationError}</div>
+      <div class="input">
+        <input placeholder="New entry to add" class="text" type="text" .value="${
+          this.entry
+        }" @input=${this.entryUpdated.bind(this)}></input>
+        <button ?disabled=${!isEntryValid} @click="${this.onSave.bind(this)}">Save</button>  
+      </div>
+      <div class="error">${validationError}</div>
     </div>`
   }
 }

--- a/client-web/src/ui/components/logoBlock.ts
+++ b/client-web/src/ui/components/logoBlock.ts
@@ -1,6 +1,7 @@
+import "../controls/logo"
+
 import { css, html, LitElement } from "lit"
 import { customElement } from "lit/decorators.js"
-import "../controls/logo"
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/client-web/src/ui/components/skills.ts
+++ b/client-web/src/ui/components/skills.ts
@@ -1,8 +1,11 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property } from "lit/decorators.js"
 import "../controls/panel"
 import "../controls/icon"
+
+import { css, html, LitElement } from "lit"
+import { customElement, property } from "lit/decorators.js"
+
 import { SkillData } from "../../../bridge/pkg"
+import { IconName } from "../controls/icon"
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -39,13 +42,13 @@ export class Skills extends LitElement {
   `
 
   skillIcon(kind: string) {
-    let icon = null
+    let icon: IconName | null = null
     if (kind == "physical") {
-      icon = "person-running" as const
+      icon = "activityPhysical"
     } else if (kind == "intelligent") {
-      icon = "brain" as const
+      icon = "activityIntelligent"
     } else if (kind == "creative") {
-      icon = "palette" as const
+      icon = "activityCreative"
     }
     if (icon) {
       return html`<q-icon class="icon" name=${icon}></q-icon>`

--- a/client-web/src/ui/components/statusBar.ts
+++ b/client-web/src/ui/components/statusBar.ts
@@ -1,6 +1,8 @@
+import "../controls/logo"
+
 import { css, html, LitElement } from "lit"
 import { customElement, property } from "lit/decorators.js"
-import "../controls/logo"
+
 import { colors } from "../styles"
 
 declare global {

--- a/client-web/src/ui/controls/button.ts
+++ b/client-web/src/ui/controls/button.ts
@@ -1,8 +1,11 @@
+import "./logo"
+
 import { css, html, LitElement } from "lit"
 import { customElement, property } from "lit/decorators.js"
 import { classMap } from "lit/directives/class-map.js"
-import "./logo"
+
 import { font } from "../styles"
+import { IconName } from "./icon"
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -17,11 +20,26 @@ export class Button extends LitElement {
     css`
       .root button {
         color: white;
+      }
+      .root:not(.iconButton) button {
         background-color: black;
       }
-      .disabled button {
+      .root:not(.iconButton).disabled button {
         background-color: #aaa;
         color: #fff;
+      }
+      .root.iconButton.disabled button {
+        background-color: #aaa;
+      }
+      .q-icon {
+        --icon-size: 16px;
+        margin-top: -3px;
+        margin-bottom: 3px;
+        display: block;
+      }
+      .iconButton button {
+        padding: 0px;
+        margin: 0px;
       }
     `,
   ]
@@ -32,17 +50,21 @@ export class Button extends LitElement {
   @property({ type: Boolean })
   isSubmit = false
 
+  @property({ type: String })
+  icon: IconName | null = null
+
   onClick() {
     this.dispatchEvent(new Event("clicked"))
   }
 
   render() {
-    const classes = { disabled: this.disabled, root: true }
+    const classes = { disabled: this.disabled, root: true, iconButton: this.icon != null }
     const buttonType = this.isSubmit ? "submit" : "button"
+    const content = this.icon
+      ? html`<q-icon class="q-icon" name=${this.icon}></q-icon>`
+      : html`<slot></slot>`
     return html`<div class=${classMap(classes)}>
-      <button @click="${this.onClick.bind(this)}" type="${buttonType}">
-        <slot></slot>
-      </button>
+      <button @click="${this.onClick.bind(this)}" type="${buttonType}">${content}</button>
     </div>`
   }
 }

--- a/client-web/src/ui/controls/icon.ts
+++ b/client-web/src/ui/controls/icon.ts
@@ -1,9 +1,13 @@
+import "./logo"
+
+import brain from "@fortawesome/fontawesome-free/svgs/solid/brain.svg"
+import palette from "@fortawesome/fontawesome-free/svgs/solid/palette.svg"
+import personRunning from "@fortawesome/fontawesome-free/svgs/solid/person-running.svg"
+import squarePen from "@fortawesome/fontawesome-free/svgs/solid/square-pen.svg"
+import squarePlus from "@fortawesome/fontawesome-free/svgs/solid/square-plus.svg"
+import squareXmark from "@fortawesome/fontawesome-free/svgs/solid/square-xmark.svg"
 import { css, html, LitElement } from "lit"
 import { customElement, property } from "lit/decorators.js"
-import "./logo"
-import brain from "@fortawesome/fontawesome-free/svgs/solid/brain.svg"
-import personRunning from "@fortawesome/fontawesome-free/svgs/solid/person-running.svg"
-import palette from "@fortawesome/fontawesome-free/svgs/solid/palette.svg"
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -11,32 +15,35 @@ declare global {
   }
 }
 
+export type IconName =
+  | "activityIntelligent"
+  | "activityPhysical"
+  | "activityCreative"
+  | "delete"
+  | "add"
+  | "edit"
 @customElement("q-icon")
 export class Icon extends LitElement {
   @property({ type: String })
-  name!: "brain" | "person-running" | "palette"
+  name!: IconName
 
   static styles = css`
     .icon {
       width: var(--icon-size, 64px);
       height: var(--icon-size, 64px);
     }
-    .icon img {
-      color: pink;
-    }
   `
 
   render() {
-    let icon = null
-
-    if (this.name == "brain") {
-      icon = brain as unknown
-    } else if (this.name == "person-running") {
-      icon = personRunning as unknown
-    } else {
-      icon = palette as unknown
+    const icons: Record<IconName, unknown> = {
+      activityCreative: palette,
+      activityIntelligent: brain,
+      activityPhysical: personRunning,
+      delete: squareXmark,
+      add: squarePlus,
+      edit: squarePen,
     }
-
+    const icon = icons[this.name]
     if (icon) {
       return html`<div class="icon"><img src=${icon} /></div>`
     } else {

--- a/client-web/src/ui/controls/logo.ts
+++ b/client-web/src/ui/controls/logo.ts
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from "lit"
 import { customElement } from "lit/decorators.js"
+
 import logo from "./logo_512.png"
 
 declare global {

--- a/client-web/src/ui/controls/notification.ts
+++ b/client-web/src/ui/controls/notification.ts
@@ -1,7 +1,9 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property } from "lit/decorators.js"
 import "./logo"
 import "../controls/button"
+
+import { css, html, LitElement } from "lit"
+import { customElement, property } from "lit/decorators.js"
+
 import { colors, font } from "../styles"
 
 declare global {

--- a/client-web/src/ui/controls/panel.ts
+++ b/client-web/src/ui/controls/panel.ts
@@ -1,6 +1,8 @@
+import "./logo"
+
 import { css, html, LitElement } from "lit"
 import { customElement, property } from "lit/decorators.js"
-import "./logo"
+
 import { colors, font } from "../styles"
 
 declare global {

--- a/client-web/src/ui/pages/devcards.ts
+++ b/client-web/src/ui/pages/devcards.ts
@@ -1,6 +1,3 @@
-import { html, LitElement, TemplateResult } from "lit"
-import { customElement, property, state } from "lit/decorators.js"
-import { DateDay } from "../../../bridge/pkg/qqself_client_web_bridge"
 import "../components/skills"
 import "../components/entryInput"
 import "../components/queryResults"
@@ -9,9 +6,14 @@ import "../controls/panel"
 import "../controls/notification"
 import "../controls/icon"
 import "../pages/progress"
+
+import { html, LitElement, TemplateResult } from "lit"
+import { customElement, property, state } from "lit/decorators.js"
+
+import { DateDay } from "../../../bridge/pkg/qqself_client_web_bridge"
 import { trace } from "../../logger"
-import { EntrySaveEvent } from "../components/entryInput"
 import { OfflineApi, TestStore } from "../../utilsTests"
+import { EntrySaveEvent } from "../components/entryInput"
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -101,6 +103,14 @@ export class DevcardsPage extends LitElement {
     // Render all the devcards. If page hash ends with `/devcards:[CARD_NAME]` then only the card with such name will be rendered
     this.cards = html`<div class="devcards">
       <!-- Controls -->
+      <q-card name="Button - Normal">
+        <q-button>Normal</q-button>
+        <q-button icon="edit"></q-button>
+      </q-card>
+      <q-card name="Button - Disabled">
+        <q-button disabled>Normal</q-button>
+        <q-button icon="add" disabled></q-button>
+      </q-card>
       <q-card name="Panel">
         <q-panel title="Dev panel">
           <div>Content #1</div>
@@ -113,7 +123,7 @@ export class DevcardsPage extends LitElement {
       </q-card>
 
       <q-card name="Icon">
-        <q-icon name="brain"></q-icon>
+        <q-icon name="activityIntelligent"></q-icon>
       </q-card>
 
       <!-- Components -->

--- a/client-web/src/ui/pages/loading.ts
+++ b/client-web/src/ui/pages/loading.ts
@@ -1,6 +1,8 @@
+import "../components/logoBlock"
+
 import { html, LitElement } from "lit"
 import { customElement, property, state } from "lit/decorators.js"
-import "../components/logoBlock"
+
 import { Store } from "../../app/store"
 
 declare global {

--- a/client-web/src/ui/pages/login.ts
+++ b/client-web/src/ui/pages/login.ts
@@ -1,8 +1,10 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property, query, state } from "lit/decorators.js"
-import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
 import "../components/logoBlock"
 import "../controls/button"
+
+import { css, html, LitElement } from "lit"
+import { customElement, property, query, state } from "lit/decorators.js"
+
+import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
 import { Store } from "../../app/store"
 
 declare global {

--- a/client-web/src/ui/pages/progress.test.ts
+++ b/client-web/src/ui/pages/progress.test.ts
@@ -1,8 +1,10 @@
-import { html, render } from "lit"
-import { OfflineApi, TestStore } from "../../utilsTests"
-import { describe, test, expect } from "vitest"
-import { DateDay } from "../../../bridge/pkg"
 import "./progress"
+
+import { html, render } from "lit"
+import { describe, expect, test } from "vitest"
+
+import { DateDay } from "../../../bridge/pkg"
+import { OfflineApi, TestStore } from "../../utilsTests"
 
 describe("progress", () => {
   test("render", async () => {

--- a/client-web/src/ui/pages/progress.ts
+++ b/client-web/src/ui/pages/progress.ts
@@ -1,5 +1,3 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property, state } from "lit/decorators.js"
 import "../components/logoBlock"
 import "../controls/button"
 import "../controls/notification"
@@ -7,9 +5,12 @@ import "../components/queryResults"
 import "../components/skills"
 import "../components/statusBar"
 
+import { css, html, LitElement } from "lit"
+import { customElement, property, state } from "lit/decorators.js"
+
+import { DateDay, SkillData } from "../../../bridge/pkg"
 import { Store } from "../../app/store"
 import { EntrySaveEvent } from "../components/entryInput"
-import { DateDay, SkillData } from "../../../bridge/pkg"
 import { QueryUpdatedEvent } from "../components/queryResults"
 
 declare global {

--- a/client-web/src/ui/pages/register.ts
+++ b/client-web/src/ui/pages/register.ts
@@ -1,10 +1,12 @@
-import { css, html, LitElement } from "lit"
-import { customElement, property, state } from "lit/decorators.js"
-import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
 import "../components/logoBlock"
 import "../controls/button"
-import { Store } from "../../app/store"
+
+import { css, html, LitElement } from "lit"
+import { customElement, property, state } from "lit/decorators.js"
+
+import { Keys } from "../../../bridge/pkg/qqself_client_web_bridge"
 import * as Auth from "../../app/auth"
+import { Store } from "../../app/store"
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/client-web/src/utilsTests.ts
+++ b/client-web/src/utilsTests.ts
@@ -1,6 +1,7 @@
+import { type ExpectStatic } from "vitest"
+
 import { APIProvider, ServerApi } from "./app/api"
 import { Events, Store } from "./app/store"
-import { type ExpectStatic } from "vitest"
 
 export class TestStore extends Store {
   gotEvents = new Map()

--- a/client-web/yarn.lock
+++ b/client-web/yarn.lock
@@ -758,6 +758,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-plugin-simple-import-sort@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
+  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
+
 eslint-plugin-unused-imports@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz#d25175b0072ff16a91892c3aa72a09ca3a9e69e7"

--- a/core/src/data_views/query_results.rs
+++ b/core/src/data_views/query_results.rs
@@ -18,12 +18,25 @@ impl QueryResultsView {
         event: &ChangeEvent,
         on_view_update: &Option<Box<dyn Fn(ViewUpdate)>>,
     ) {
-        let ChangeEvent::Added(Record::Value(RecordValue::Entry(entry))) = event else { return };
+        // Extract an entry from the change event
+        let entry = if let ChangeEvent::Added(Record::Value(RecordValue::Entry(entry))) = event {
+            Some(entry)
+        } else if let ChangeEvent::Replaced {
+            from: Record::Value(RecordValue::Entry(entry_old)),
+            to: Record::Value(RecordValue::Entry(entry_new)),
+        } = event
+        {
+            // We are replacing an entry, so remove old one if existed
+            self.data.remove(entry_old.entry());
+            Some(entry_new)
+        } else {
+            None
+        };
 
+        let Some(entry) = entry else { return };
         if !self.query.matches(entry.entry()) {
             return; // Not a relevant entry for the query
         }
-
         self.data.insert(entry.entry().clone());
         if let Some(update) = on_view_update {
             update(ViewUpdate::QueryResults);
@@ -58,5 +71,77 @@ impl QueryResultsView {
 
     pub fn data(&self) -> &BTreeSet<Entry> {
         &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::db::RecordEntry;
+
+    use super::*;
+
+    const ENTRY_PREFIX: &str = "2000-01-01 00:00";
+
+    fn record(s: &str) -> Record {
+        Record::Value(RecordValue::Entry(RecordEntry::new(
+            1,
+            Entry::parse(&format!("{ENTRY_PREFIX} {s}")).unwrap(),
+        )))
+    }
+    fn assert_data(view: &QueryResultsView, want: Vec<&'static str>) {
+        let got: Vec<_> = view
+            .data
+            .iter()
+            .map(|v| v.to_string()[ENTRY_PREFIX.len() + 1..].to_string())
+            .collect();
+        let want: Vec<_> = want.iter().map(|v| v.to_string()).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn update_add() {
+        let mut view = QueryResultsView::default();
+        view.update_query(
+            Query::new("tag1").unwrap(),
+            BTreeMap::default().iter(),
+            &None,
+        );
+
+        // Matching entry
+        view.update(&ChangeEvent::Added(record("00:02 tag1")), &None);
+        view.update(&ChangeEvent::Added(record("00:01 tag1")), &None);
+        view.update(&ChangeEvent::Added(record("00:03 tag2")), &None);
+        assert_data(&view, vec!["00:01 tag1", "00:02 tag1"]);
+
+        // Nothing found
+        view.update_query(
+            Query::new("tag3").unwrap(),
+            BTreeMap::default().iter(),
+            &None,
+        );
+        assert_data(&view, vec![]);
+    }
+
+    #[test]
+    fn update_replace() {
+        let mut view = QueryResultsView::default();
+        view.update_query(
+            Query::new("tag1").unwrap(),
+            BTreeMap::default().iter(),
+            &None,
+        );
+        let rec1 = record("00:00 tag1. Comment1");
+        let rec2 = record("00:00 tag1. Comment2");
+        view.update(&ChangeEvent::Added(rec1.clone()), &None);
+        view.update(
+            &ChangeEvent::Replaced {
+                from: rec1,
+                to: rec2,
+            },
+            &None,
+        );
+        assert_data(&view, vec!["00:00 tag1. Comment2"]);
     }
 }


### PR DESCRIPTION
- Add `simple-import-sort` eslint rule to keep all imports sorted automatically
- `QueryResults` entries now have an `edit` button
- `q-button` now supports icon
- `core::QueryResults` now supports `ChangeEvent::Replaced` and have tests adding event handling