### PR TITLE
core Remove RecordEmpty and API functionality to delete the entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - run: ./run.sh lint
 
   deploy-api:
-    #if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - run: ./run.sh lint
 
   deploy-api:
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/api-sync/src/storage/payload_storage_dynamodb.rs
+++ b/api-sync/src/storage/payload_storage_dynamodb.rs
@@ -88,11 +88,7 @@ impl PayloadStorage for PayloadStorageDynamoDB {
             &payload_id,
             Some(payload.data().data()),
         )
-        .await?;
-        if let Some(prev) = payload.previous_version() {
-            self.put_item(payload.public_key(), prev, None).await?;
-        };
-        Ok(())
+        .await
     }
 
     fn find(

--- a/api-sync/src/storage/payload_storage_mem.rs
+++ b/api-sync/src/storage/payload_storage_mem.rs
@@ -34,13 +34,6 @@ impl Default for PayloadStorageMemory {
 impl PayloadStorage for PayloadStorageMemory {
     async fn set(&self, payload: Payload, payload_id: PayloadId) -> Result<(), StorageErr> {
         let mut data = self.data.lock().unwrap();
-        if let Some(prev) = payload.previous_version() {
-            if let Some(item) = data.iter_mut().find(|(public_key, payload_id, _)| {
-                public_key == payload.public_key() && payload_id == &prev.to_string()
-            }) {
-                item.2.take();
-            }
-        }
         data.push((
             payload.public_key().clone(),
             payload_id.to_string(),

--- a/client-web/bridge/src/lib.rs
+++ b/client-web/bridge/src/lib.rs
@@ -93,7 +93,6 @@ impl Keys {
             &self.0.private_key,
             Timestamp::now(),
             &plaintext,
-            None,
         )
         .map_err(|err| err.to_string())?;
         Ok(payload.data())

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -56,7 +56,6 @@ impl ApiRequest {
             &keys.private_key,
             Timestamp::now(),
             &plaintext,
-            None,
         )?;
         Ok(ApiRequest::new_set_request_encrypted(payload.data()))
     }

--- a/core/src/data_views/skills.rs
+++ b/core/src/data_views/skills.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     date_time::datetime::{DateDay, DateTimeRange},
-    db::{ChangeEvent, Notification, Record, RecordValue, ViewUpdate},
+    db::{ChangeEvent, Notification, Record, ViewUpdate},
     progress::skill::{Skill, SkillProgress},
 };
 
@@ -37,13 +37,13 @@ impl SkillsView {
         on_view_update: &Option<Box<dyn Fn(ViewUpdate)>>,
         on_notification: &Option<Box<dyn Fn(Notification)>>,
     ) {
-        let ChangeEvent::Added(Record::Value(RecordValue::Entry(entry))) = event else { return };
-        if let Some(mut skill) = Skill::from_record(entry.entry()) {
+        let ChangeEvent::Added(Record::Entry(entry)) = event else { return };
+        if let Some(mut skill) = Skill::from_record(&entry.entry) {
             // If it's a Skill - go back and re-read all previous record to accumulate duration
             for (_, record) in all.clone() {
-                let Record::Value(RecordValue::Entry(entry)) = record else { continue; };
-                if skill.selector().matches(entry.entry()) {
-                    skill.add_duration(entry.entry().date_range.duration());
+                let Record::Entry(entry) = record else { continue; };
+                if skill.selector().matches(&entry.entry) {
+                    skill.add_duration(entry.entry.date_range.duration());
                 }
             }
             self.data.insert(skill.title().to_string(), skill.clone());
@@ -54,14 +54,14 @@ impl SkillsView {
         } else {
             // If it's a record - add it to the corresponding Skill if exists
             for (_, skill) in self.data.iter_mut() {
-                if skill.selector().matches(entry.entry()) {
-                    skill.add_duration(entry.entry().date_range.duration());
+                if skill.selector().matches(&entry.entry) {
+                    skill.add_duration(entry.entry.date_range.duration());
                 }
             }
             // Second iteration to notify about skills progress
             let mut send_total_notification = true;
             for (_, skill) in self.data.iter() {
-                if skill.selector().matches(entry.entry()) {
+                if skill.selector().matches(&entry.entry) {
                     self.process_update(skill, on_view_update);
                     if let (Some(on_notification), Some(now), true) =
                         (on_notification, now, interactive)
@@ -71,7 +71,7 @@ impl SkillsView {
                             on_notification,
                             now,
                             all.clone(),
-                            Some(entry.entry().date_range()),
+                            Some(entry.entry.date_range()),
                             send_total_notification,
                         );
                         // Entry may have multiple tags/skills attached, but we want notification about total processed only once
@@ -148,20 +148,20 @@ impl SkillsView {
             Checkpoint::by_skill(now, Period::Week, &[1, 3, 5], 5, skill.title().to_string()),
         ];
         for (_, rec) in all {
-            let Record::Value(RecordValue::Entry(entry)) = rec else { continue; };
+            let Record::Entry(entry) = rec else { continue; };
             for checkpoint in checkpoints_total.iter_mut() {
                 // If entry belongs to any skill then it's added to total notification calculations
                 if self
                     .data
                     .iter()
-                    .any(|(_, s)| s.selector().matches(entry.entry()))
+                    .any(|(_, s)| s.selector().matches(&entry.entry))
                 {
-                    checkpoint.add(entry.entry().date_range);
+                    checkpoint.add(entry.entry.date_range);
                 }
             }
-            if skill.selector().matches(entry.entry()) {
+            if skill.selector().matches(&entry.entry) {
                 for checkpoint in checkpoints_skills.iter_mut() {
-                    checkpoint.add(entry.entry().date_range)
+                    checkpoint.add(entry.entry.date_range)
                 }
             }
         }
@@ -314,11 +314,11 @@ mod tests {
 
     impl TestSkillView {
         fn add(&mut self, entry: &str) {
-            let record = Record::Value(RecordValue::Entry(RecordEntry::new(
-                1,
-                Entry::parse(entry).unwrap(),
-            )));
-            self.entries.insert(record.daterange(), record.clone());
+            let record = Record::Entry(RecordEntry {
+                revision: 1,
+                entry: Entry::parse(entry).unwrap(),
+            });
+            self.entries.insert(*record.daterange(), record.clone());
             self.skill_view.update(
                 self.entries.iter(),
                 &ChangeEvent::Added(record),
@@ -334,11 +334,11 @@ mod tests {
             entry: &str,
             now: Option<DateDay>,
         ) -> Vec<SkillsNotification> {
-            let record = Record::Value(RecordValue::Entry(RecordEntry::new(
-                1,
-                Entry::parse(entry).unwrap(),
-            )));
-            self.entries.insert(record.daterange(), record.clone());
+            let record = Record::Entry(RecordEntry {
+                revision: 1,
+                entry: Entry::parse(entry).unwrap(),
+            });
+            self.entries.insert(*record.daterange(), record.clone());
             let called = Rc::new(RefCell::new(Vec::new()));
             let called_clone = called.clone();
             self.skill_view.update(

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -9,85 +9,44 @@ use crate::record::{Entry, PropVal, Tag};
 
 #[derive(Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 pub struct RecordEntry {
-    revision: usize,
-    entry: Entry,
-}
-
-impl RecordEntry {
-    pub fn new(revision: usize, entry: Entry) -> Self {
-        Self { revision, entry }
-    }
-    pub fn entry(&self) -> &Entry {
-        &self.entry
-    }
-}
-
-#[derive(Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
-pub struct RecordEmpty {
-    revision: usize,
-    date_range: DateTimeRange,
-}
-
-#[derive(Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
-pub enum RecordValue {
-    Entry(RecordEntry),
-    Empty(RecordEmpty),
-}
-
-impl RecordValue {
-    fn date_range(&self) -> DateTimeRange {
-        match self {
-            RecordValue::Entry(v) => v.entry.date_range,
-            RecordValue::Empty(v) => v.date_range,
-        }
-    }
-    fn revision(&self) -> usize {
-        match self {
-            RecordValue::Entry(v) => v.revision,
-            RecordValue::Empty(v) => v.revision,
-        }
-    }
+    pub(crate) revision: usize,
+    pub(crate) entry: Entry,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct RecordConflict {
     revision: usize,
-    entries: BTreeSet<RecordValue>,
-}
-
-impl RecordConflict {
-    fn date_range(&self) -> DateTimeRange {
-        let entry = self
-            .entries
-            .iter()
-            .next()
-            .expect("Conflict should always have an entry");
-        entry.date_range()
-    }
+    entries: BTreeSet<RecordEntry>,
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum Record {
-    Value(RecordValue),
+    Entry(RecordEntry),
     Conflict(RecordConflict),
 }
 
 impl Record {
     fn revision(&self) -> usize {
         match self {
-            Record::Value(v) => v.revision(),
+            Record::Entry(v) => v.revision,
             Record::Conflict(v) => v.revision,
         }
     }
-    pub fn daterange(&self) -> DateTimeRange {
+    pub fn daterange(&self) -> &DateTimeRange {
         match self {
-            Record::Value(v) => v.date_range(),
-            Record::Conflict(v) => v.date_range(),
+            Record::Entry(v) => &v.entry.date_range,
+            Record::Conflict(v) => {
+                &v.entries
+                    .first()
+                    .expect("Conflict should have entries")
+                    .entry
+                    .date_range
+            }
         }
     }
 
     pub fn from_entry(entry: Entry, revision: usize) -> Self {
-        Self::Value(RecordValue::Entry(RecordEntry { revision, entry }))
+        Self::Entry(RecordEntry { revision, entry })
     }
 }
 
@@ -98,6 +57,7 @@ pub enum ChangeEvent {
         from: Record,
         to: Record,
     },
+    // TODO Do we actually need that? Replaced is essentially the same?
     ConflictUpdated {
         from: RecordConflict,
         to: RecordConflict,
@@ -146,25 +106,8 @@ impl DB {
     }
 
     /// Adds new record to the DB. Interactively means user is adding a record right now. If records are restored from
-    /// cache, fetched from API then it's considered not interactive and simple `DB::add` should be called instead.
-    /// In interactive mode user may benefit from `Notifications`, so those are emitted in case of noticeable progress
-    pub fn add_interactively(&mut self, record: Record, now: DateDay) -> Option<ChangeEvent> {
-        let event = self.merge(record);
-        if let Some(event) = &event {
-            self.view_query_results.update(event, &self.on_view_update);
-            self.view_skills.update(
-                self.entries.iter(),
-                event,
-                true,
-                Some(now),
-                &self.on_view_update,
-                &self.on_notification,
-            );
-        }
-        event
-    }
-
-    /// Adds new record to the DB. Notifications are not emitted as adding considered not interactive
+    /// cache, fetched from API then it's considered not interactive. In interactive mode user may benefit from
+    /// `Notifications`, so those are emitted in case of noticeable progress
     pub fn add(
         &mut self,
         record: Record,
@@ -206,10 +149,10 @@ impl DB {
         //     - If new one is conflict, but existing record is value - replace existing record with new conflict with added existing record
         let mut record_new = record_new;
         let entry_new_key = record_new.daterange();
-        let mut record_old = match self.entries.get_mut(&entry_new_key) {
+        let mut record_old = match self.entries.get_mut(entry_new_key) {
             None => {
                 let event = ChangeEvent::Added(record_new.clone());
-                self.entries.insert(entry_new_key, record_new);
+                self.entries.insert(*entry_new_key, record_new);
                 return Some(event); // New record - append
             }
             Some(v) => v,
@@ -240,19 +183,19 @@ impl DB {
                     to: conflict_old.clone(),
                 })
             }
-            (Record::Value(value_old), Record::Value(value_new)) => {
+            (Record::Entry(value_old), Record::Entry(value_new)) => {
                 // Two conflicting values - replace existing record with Conflict value and append new entry there
                 let value_before = value_old.clone();
                 *record_old = Record::Conflict(RecordConflict {
-                    revision: value_new.revision(),
+                    revision: value_new.revision,
                     entries: BTreeSet::from([value_old.clone(), value_new.to_owned()]),
                 });
                 Some(ChangeEvent::Replaced {
-                    from: Record::Value(value_before),
+                    from: Record::Entry(value_before),
                     to: record_old.clone(),
                 })
             }
-            (Record::Conflict(conflict_old), Record::Value(value_new)) => {
+            (Record::Conflict(conflict_old), Record::Entry(value_new)) => {
                 let conflict_before = conflict_old.clone();
                 // Existing conflict - append new entry
                 conflict_old.entries.insert(value_new.to_owned());
@@ -262,17 +205,17 @@ impl DB {
                     to: conflict_old.clone(),
                 })
             }
-            (Record::Value(value_old), Record::Conflict(conflict_new)) => {
+            (Record::Entry(value_old), Record::Conflict(conflict_new)) => {
                 // Existing value, but new conflict, merge to conflict
                 let value_before = value_old.clone();
                 let mut entries = conflict_new.entries.to_owned();
                 entries.insert(value_old.clone());
                 *record_old = Record::Conflict(RecordConflict {
-                    revision: value_old.revision(),
+                    revision: value_old.revision,
                     entries,
                 });
                 Some(ChangeEvent::Replaced {
-                    from: Record::Value(value_before),
+                    from: Record::Entry(value_before),
                     to: record_old.clone(),
                 })
             }
@@ -415,7 +358,7 @@ mod tests {
         let entries: BTreeSet<_> = records
             .iter()
             .map(|v| {
-                if let Record::Value(v) = v {
+                if let Record::Entry(v) = v {
                     return v.clone();
                 }
                 unreachable!()
@@ -426,7 +369,7 @@ mod tests {
 
     fn modified_conflict(conflict: &RecordConflict, record: Record) -> RecordConflict {
         let mut conflict = conflict.clone();
-        if let Record::Value(v) = record {
+        if let Record::Entry(v) = record {
             conflict.entries.insert(v);
             conflict.revision += 1;
             return conflict;
@@ -436,7 +379,7 @@ mod tests {
 
     fn parse_entry(text: &str, revision: usize) -> Record {
         let entry = Entry::parse(&format!("{ENTRY_PREFIX} {}", text)).unwrap();
-        Record::Value(RecordValue::Entry(RecordEntry { revision, entry }))
+        Record::Entry(RecordEntry { revision, entry })
     }
 
     #[derive(Default)]
@@ -467,7 +410,7 @@ mod tests {
                 .map(|(date_range, record)| (*date_range, record))
                 .collect();
             let want: Vec<(DateTimeRange, &Record)> =
-                want.into_iter().map(|v| (v.daterange(), v)).collect();
+                want.into_iter().map(|v| (*v.daterange(), v)).collect();
             assert_eq!(got, want);
         }
 


### PR DESCRIPTION
- Remove support of empty entries from core and API and make it append-only log. Previously we allowed to replace entries by adding a new entry and then resetting the value of the previous one. Upcoming revision support will support such functionality and will make overall design simpler