### PR TITLE
client-cli Migrate from unmaintained structopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,12 +281,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -304,17 +343,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -823,18 +851,49 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -1286,21 +1345,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1952,30 +1999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,11 +2031,11 @@ dependencies = [
 name = "qqself-client-cli"
 version = "0.0.0"
 dependencies = [
+ "clap",
  "qqself-core",
  "rayon",
  "reqwest",
  "serde",
- "structopt",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2581,33 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2667,15 +2666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2955,18 +2945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,6 +2978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,12 +3000,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "core",

--- a/client-cli/Cargo.toml
+++ b/client-cli/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 qqself-core = {path = "../core", features = ["serde"] }
 reqwest = "0.11.20"
 serde = { version = "1.0", features = ["derive"] }
-structopt = "0.3.25"
 tokio = { version = "1.32.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["local-time", "env-filter"] }
 rayon = "1.5.3"
+clap = { version = "4.4.2", features = ["derive"] }

--- a/client-cli/README.md
+++ b/client-cli/README.md
@@ -1,91 +1,60 @@
 # qqself-client-cli
 Command line client for qqself with common operations
 <pre>
-qqself-client-cli 0.0.0
+Usage: qqself-client-cli <COMMAND>
 
-USAGE:
-    qqself-client-cli <SUBCOMMAND>
+Commands:
+  init      Creates new key file
+  upload    Uploads all the records from journal file to the server
+  download  Download all the entries from the server to the file
+  report    Read the journal and report current state of things
+  delete    Delete all the records from the server
+  help      Print this message or the help of the given subcommand(s)
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-SUBCOMMANDS:
-    delete      Delete all the records from the server
-    download    Download all the entries from the server to the file
-    help        Prints this message or the help of the given subcommand(s)
-    init        Creates new key file
-    report      Read the journal and report current state of things
-    upload      Uploads all the records from journal file to the server
+Options:
+  -h, --help  Print help
 
 # SUBCOMMAND: delete
-Delete all the records from the server
 
-USAGE:
-    qqself-client-cli delete [OPTIONS]
+Usage: qqself-client-cli delete [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -k, --keys-path <keys-path>    Path to key file [default: qqself_keys.txt]
+Options:
+  -k, --keys-path <KEYS_PATH>  Path to key file [default: qqself_keys.txt]
+  -h, --help                   Print help
 
 # SUBCOMMAND: download
-Download all the entries from the server to the file
 
-USAGE:
-    qqself-client-cli download [OPTIONS]
+Usage: qqself-client-cli download [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -k, --keys-path <keys-path>            Path to key file [default: qqself_keys.txt]
-    -o, --output-folder <output-folder>    Path to folder where journal will be created with the name format of
-                                           `qqself_journal_[TODAY].txt` [default: .]
+Options:
+  -o, --output-folder <OUTPUT_FOLDER>  Path to folder where journal will be created with the name format of `qqself_journal_[TODAY].txt` [default: .]
+  -k, --keys-path <KEYS_PATH>          Path to key file [default: qqself_keys.txt]
+  -h, --help                           Print help
 
 # SUBCOMMAND: init
-Creates new key file
 
-USAGE:
-    qqself-client-cli init [FLAGS] [OPTIONS]
+Usage: qqself-client-cli init [OPTIONS]
 
-FLAGS:
-    -h, --help         Prints help information
-    -o, --overwrite    If existing config file should be ignored and overwritten
-    -V, --version      Prints version information
-
-OPTIONS:
-    -k, --keys-path <keys-path>    Where new generated keys will be stored [default: qqself_keys.txt]
+Options:
+  -k, --keys-path <KEYS_PATH>  Where new generated keys will be stored [default: qqself_keys.txt]
+  -o, --overwrite              If existing config file should be ignored and overwritten
+  -h, --help                   Print help
 
 # SUBCOMMAND: report
-Read the journal and report current state of things
 
-USAGE:
-    qqself-client-cli report [OPTIONS]
+Usage: qqself-client-cli report [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -j, --journal-path <journal-path>    Path to journal file with all the entries [default: journal.txt]
-    -p, --period <period>                Period of time to make a report for [default: day]  [possible values: Day,
-                                         Week, Month, Year]
+Options:
+  -j, --journal-path <JOURNAL_PATH>  Path to journal file with all the entries [default: journal.txt]
+  -p, --period <PERIOD>              Period of time to make a report for [default: day] [possible values: day, week, month, year]
+  -h, --help                         Print help
 
 # SUBCOMMAND: upload
-Uploads all the records from journal file to the server
 
-USAGE:
-    qqself-client-cli upload [OPTIONS]
+Usage: qqself-client-cli upload [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -j, --journal-path <journal-path>    Path to journal file with all the entries [default: journal.txt]
-    -k, --keys-path <keys-path>          Path to key file [default: qqself_keys.txt]
+Options:
+  -j, --journal-path <JOURNAL_PATH>  Path to journal file with all the entries [default: journal.txt]
+  -k, --keys-path <KEYS_PATH>        Path to key file [default: qqself_keys.txt]
+  -h, --help                         Print help
 </pre>

--- a/client-cli/src/main.rs
+++ b/client-cli/src/main.rs
@@ -1,3 +1,4 @@
+use clap::{self, Parser};
 use operations::{
     delete::{delete, DeleteOpts},
     download::{download, DownloadOpts},
@@ -5,14 +6,13 @@ use operations::{
     report::{report, ReportOpts},
     upload::{upload, UploadOpts},
 };
-use structopt::StructOpt;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 mod http;
 mod key_file;
 mod operations;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 enum Opts {
     Init(InitOpts),
     Upload(UploadOpts),
@@ -32,7 +32,7 @@ fn main() {
                 .from_env_lossy(),
         )
         .init();
-    match Opts::from_args() {
+    match Opts::parse() {
         Opts::Init(opts) => init(opts),
         Opts::Upload(opts) => upload(opts),
         Opts::Report(opts) => report(opts),

--- a/client-cli/src/operations/delete.rs
+++ b/client-cli/src/operations/delete.rs
@@ -1,18 +1,17 @@
 use std::{io, path::Path, thread};
 
+use clap::Parser;
 use qqself_core::api::ApiRequest;
-
-use structopt::StructOpt;
 
 use tracing::{info, warn};
 
 use crate::{http::Http, key_file::KeyFile};
 
-#[derive(StructOpt, Debug)]
-#[structopt(about = "Delete all the records from the server")]
+#[derive(Parser, Debug)]
+#[command(about = "Delete all the records from the server")]
 pub struct DeleteOpts {
     /// Path to key file
-    #[structopt(short, long, default_value = "qqself_keys.txt")]
+    #[arg(short, long, default_value = "qqself_keys.txt")]
     keys_path: String,
 }
 

--- a/client-cli/src/operations/download.rs
+++ b/client-cli/src/operations/download.rs
@@ -4,6 +4,7 @@ use std::{
     thread::{self},
 };
 
+use clap::Parser;
 use qqself_core::{
     api::ApiRequest,
     binary_text::BinaryToText,
@@ -13,21 +14,20 @@ use qqself_core::{
 };
 use rayon::prelude::*;
 use rayon::str::ParallelString;
-use structopt::StructOpt;
 use tokio::sync::mpsc;
 use tracing::info;
 
 use crate::{http::Http, key_file::KeyFile};
 
-#[derive(StructOpt, Debug)]
-#[structopt(about = "Download all the entries from the server to the file")]
+#[derive(Parser, Debug)]
+#[command(about = "Download all the entries from the server to the file")]
 pub struct DownloadOpts {
     /// Path to folder where journal will be created with the name format of `qqself_journal_[TODAY].txt`
-    #[structopt(short, long, default_value = ".")]
+    #[arg(short, long, default_value = ".")]
     output_folder: String,
 
     /// Path to key file
-    #[structopt(short, long, default_value = "qqself_keys.txt")]
+    #[arg(short, long, default_value = "qqself_keys.txt")]
     keys_path: String,
 }
 

--- a/client-cli/src/operations/init.rs
+++ b/client-cli/src/operations/init.rs
@@ -1,19 +1,19 @@
 use std::{path::Path, process::exit};
 
 use crate::key_file::KeyFile;
+use clap::Parser;
 use qqself_core::encryption::keys::Keys;
-use structopt::StructOpt;
 use tracing::{error, info};
 
-#[derive(StructOpt, Debug)]
-#[structopt(about = "Creates new key file")]
+#[derive(Parser, Debug)]
+#[command(about = "Creates new key file")]
 pub struct InitOpts {
     /// Where new generated keys will be stored
-    #[structopt(short, long, default_value = "qqself_keys.txt")]
+    #[arg(short, long, default_value = "qqself_keys.txt")]
     keys_path: String,
 
     /// If existing config file should be ignored and overwritten
-    #[structopt(short, long)]
+    #[arg(short, long)]
     overwrite: bool,
 }
 

--- a/client-cli/src/operations/report.rs
+++ b/client-cli/src/operations/report.rs
@@ -5,32 +5,30 @@ use std::{
     process::exit,
 };
 
+use clap::{Parser, ValueEnum};
 use qqself_core::{
     date_time::datetime::DateDay,
     db::{Query, Record, DB},
 };
-use structopt::{clap::arg_enum, StructOpt};
 use tracing::error;
 
-arg_enum! {
-    #[derive(Debug)]
-    enum TimePeriod {
-        Day,
-        Week,
-        Month,
-        Year,
-    }
+#[derive(Debug, Clone, ValueEnum)]
+enum TimePeriod {
+    Day,
+    Week,
+    Month,
+    Year,
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt(about = "Read the journal and report current state of things")]
+#[derive(Parser, Debug)]
+#[command(about = "Read the journal and report current state of things")]
 pub struct ReportOpts {
     /// Path to journal file with all the entries
-    #[structopt(short, long, default_value = "journal.txt")]
+    #[arg(short, long, default_value = "journal.txt")]
     journal_path: String,
 
     /// Period of time to make a report for
-    #[structopt(short, long, possible_values = &TimePeriod::variants(), case_insensitive = true, default_value = "day")]
+    #[arg(short, long, value_enum, default_value = "day")]
     period: TimePeriod,
 }
 

--- a/client-cli/src/operations/upload.rs
+++ b/client-cli/src/operations/upload.rs
@@ -6,23 +6,23 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use clap::Parser;
 use qqself_core::{api::ApiRequest, record::Entry};
 use rayon::prelude::{ParallelBridge, ParallelIterator};
-use structopt::StructOpt;
 use tokio::sync::mpsc;
 use tracing::{error, info};
 
 use crate::{http::Http, key_file::KeyFile};
 
-#[derive(StructOpt, Debug)]
-#[structopt(about = "Uploads all the records from journal file to the server")]
+#[derive(Parser, Debug)]
+#[command(about = "Uploads all the records from journal file to the server")]
 pub struct UploadOpts {
     /// Path to journal file with all the entries
-    #[structopt(short, long, default_value = "journal.txt")]
+    #[arg(short, long, default_value = "journal.txt")]
     journal_path: String,
 
     /// Path to key file
-    #[structopt(short, long, default_value = "qqself_keys.txt")]
+    #[arg(short, long, default_value = "qqself_keys.txt")]
     keys_path: String,
 }
 

--- a/core/src/binary_text.rs
+++ b/core/src/binary_text.rs
@@ -79,7 +79,7 @@ mod tests {
     #[test]
     #[wasm_bindgen_test]
     fn binary_text_errors() {
-        let bad_characters = r#"C:\\Windows\cmd.exe"#;
+        let bad_characters = r"C:\\Windows\cmd.exe";
         assert!(BinaryToText::new_from_encoded(bad_characters.to_string()).is_none());
     }
 }

--- a/core/src/data_views/skills.rs
+++ b/core/src/data_views/skills.rs
@@ -54,7 +54,9 @@ impl SkillsView {
         if let Some(mut skill) = Skill::from_record(entry) {
             // If it's a Skill - go back and re-read all previous record to accumulate duration
             for (_, record) in all.clone() {
-                let Record::Entry(entry) = record else { continue; };
+                let Record::Entry(entry) = record else {
+                    continue;
+                };
                 if skill.selector().matches(entry) {
                     skill.add_duration(entry.date_range.duration());
                 }
@@ -181,7 +183,9 @@ impl SkillsView {
             Checkpoint::by_skill(now, Period::Week, &[1, 3, 5], 5, skill.title().to_string()),
         ];
         for (_, rec) in all {
-            let Record::Entry(entry) = rec else { continue; };
+            let Record::Entry(entry) = rec else {
+                continue;
+            };
             for checkpoint in checkpoints_total.iter_mut() {
                 // If entry belongs to any skill then it's added to total notification calculations
                 if self.data.iter().any(|(_, s)| s.selector().matches(entry)) {

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -47,7 +47,9 @@ impl Record {
     }
 
     pub fn is_deleted_record(&self) -> bool {
-        let Record::Entry(entry) = self else { return false };
+        let Record::Entry(entry) = self else {
+            return false;
+        };
         for tag in &entry.tags {
             if tag.name == "entry" {
                 for prop in &tag.props {

--- a/run.sh
+++ b/run.sh
@@ -22,8 +22,6 @@ usage() {
 
 # Install dependencies and required tooling for the development
 deps() {
-  ver="1.72.0"
-  rustup install "$ver" && rustup default "$ver"
   cargo fetch
   (cd client-web && yarn install) 
 }

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,7 @@ usage() {
 
 # Install dependencies and required tooling for the development
 deps() {
+  rustup default 1.72.0
   cargo fetch
   (cd client-web && yarn install) 
 }

--- a/run.sh
+++ b/run.sh
@@ -22,7 +22,8 @@ usage() {
 
 # Install dependencies and required tooling for the development
 deps() {
-  rustup default 1.72.0
+  ver="1.72.0"
+  rustup install "$ver" && rustup default "$ver"
   cargo fetch
   (cd client-web && yarn install) 
 }


### PR DESCRIPTION
- Migrate from unmaintained structopt to clap. It should also help us to unblock solving low severity security issues
- Linter was failing as latest rust 1.72 clippy introduced a new rules and we are using always latest on CI - this PR fixes all the issues
- ~~Now rust version is fixed (1.72.0 for now) and things should be more stable, but it means manual updates will be needed~~ Removed as CI got broken, `VERGEN` stopped working, not worth the investigation, let's live on the edge then