### PR TITLE
client-web Fix CSP image loading

### DIFF
--- a/client-web/nginx.conf
+++ b/client-web/nginx.conf
@@ -20,7 +20,7 @@ http {
         # Security
         # HACK `unsafe-inline` solves Safari issue as it doesn't support adopted StyleSheets
         # HACK `unsafe-eval` solves loading of WebAssembly. 
-        add_header Content-Security-Policy "object-src 'none'; style-src 'unsafe-inline' 'self'; script-src 'unsafe-eval' 'self'; connect-src https://api.qqself.com 'self'; default-src 'self'";
+        add_header Content-Security-Policy "img-src 'self' data:; object-src 'none'; style-src 'unsafe-inline' 'self'; script-src 'unsafe-eval' 'self'; connect-src https://api.qqself.com 'self'; default-src 'self'";
         add_header Referrer-Policy "no-referrer";
         add_header Strict-Transport-Security "max-age=63072000; preload";
         add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
`data:image/svg+xml` images are not loaded and currently Safari shows bunch of errors like
```
Refused to load data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20448%20512'%3e%3c!--
!%20Font%20Awesome%20Free%206.4.2%20by%20@fontawesome%20-%20https://fontawesome.com%20License%20-
%20https://fontawesome.com/license/free%20(Icons:%20CC%20BY%204.0,%20Fonts:%20SIL%20OFL%201.1,%20Code:%
20MIT%20License)%20Copyright%202023%20Fonticons,%20Inc.%20--
%3e%3cpath%20d='M64%2032C28.7%2032%200%2060.7%200%2096V416c0%2035.3%2028.7%2064%2064%2064H
384c35.3%200%2064-28.7%2064-64V96c0-35.3-28.7-64-64-64H64zm79%20143c9.4-9.4%2024.6-
9.4%2033.9%200l47%2047%2047-47c9.4-9.4%2024.6-9.4%2033.9%200s9.4%2024.6%200%2033.9l-
47%2047%2047%2047c9.4%209.4%209.4%2024.6%200%2033.9s-24.6%209.4-33.9%200l-47-47-47%2047c-
9.4%209.4-24.6%209.4-33.9%200s-9.4-24.6%200-33.9l47-47-47-47c-9.4-9.4-9.4-24.6%200-33.9z'/%3e%3c/svg%3e
because it appears in neither the img-src directive nor the default-src directive of the Content Security Policy.
```