### PR TITLE
core Fix overflow when too old records were replaced in Week view

### DIFF
--- a/client-web/bridge/Cargo.toml
+++ b/client-web/bridge/Cargo.toml
@@ -15,3 +15,6 @@ js-sys = { version = "0.3.65" }
 
 [build-dependencies]
 vergen = { version = "8.2.6", features = ["build", "cargo", "git", "git2", "rustc"] }
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
I've enabled `overflow-check` in Cargo for the bridge, but it still failed to catch the error in WebAssembly context. I'm not sure why, but let's keep it - maybe it will help us catching other overflows