### PR TITLE
core-bindings-c Allow to set panic hook, like in WASM bindings

### DIFF
--- a/client-ios/qqself/App/Logger.swift
+++ b/client-ios/qqself/App/Logger.swift
@@ -2,6 +2,7 @@
 // logging workflows across whole code base
 
 import Foundation
+import qqselfCoreLib
 
 enum LogLevel: String {
     case trace = "trace"
@@ -36,3 +37,13 @@ let warn = { log(logLevel: .warn, msg: $0) }
 let info = { log(logLevel: .info, msg: $0) }
 let debug = { log(logLevel: .debug, msg: $0) }
 let trace = { log(logLevel: .trace, msg: $0) } 
+
+class OnPanic: PanicHook {
+    func onPanic(msg: String) {
+        error(msg)
+    }
+}
+
+func setPanicHook() {
+    setPanicHook(hook: OnPanic())
+}

--- a/client-ios/qqself/App/qqselfApp.swift
+++ b/client-ios/qqself/App/qqselfApp.swift
@@ -1,13 +1,22 @@
 import SwiftUI
 import qqselfCoreLib
 
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        
+        info(buildInfo())
+        setPanicHook()
+
+        return true
+    }
+}
+
 @main
 struct qqselfApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     var body: some Scene {
         WindowGroup {
-            MainView().onAppear {
-                info(buildInfo())
-            }
+            MainView()
         }
     }
 }

--- a/core-bindings-c/src/lib.rs
+++ b/core-bindings-c/src/lib.rs
@@ -1,3 +1,4 @@
+use std::panic;
 use std::sync::Arc;
 
 use qqself_core::encryption::cryptor::CryptorError;
@@ -8,6 +9,9 @@ uniffi::include_scaffolding!("qqself");
 pub use qqself_core::api::{ApiRequests as Api, Request};
 pub use qqself_core::build_info;
 pub use qqself_core::encryption::cryptor::Cryptor;
+
+pub mod panic_hook;
+pub use panic_hook::{set_panic_hook, PanicHook};
 
 pub fn string_hash(input: String) -> String {
     StableHash::hash_string(&input).to_string()

--- a/core-bindings-c/src/panic_hook.rs
+++ b/core-bindings-c/src/panic_hook.rs
@@ -1,0 +1,23 @@
+// Panic handler - in case of panic we want to send error logs to the calling side
+// Similar to WASM console_error_panic_hook
+
+use std::{panic, sync::Mutex};
+
+static SAVED_HOOK: Mutex<Option<Box<dyn PanicHook>>> = Mutex::new(None);
+
+pub trait PanicHook: Send + Sync {
+    fn on_panic(&self, message: String);
+}
+
+pub fn set_panic_hook(hook: Box<dyn PanicHook>) {
+    let mut guard = SAVED_HOOK.lock().unwrap();
+    if guard.is_some() {
+        return; // Hook was already set
+    }
+    // Store hook in static variable to make it accessible in panic::set_hook
+    *guard = Some(hook);
+    panic::set_hook(Box::new(|info: &panic::PanicInfo| {
+        let hook = SAVED_HOOK.lock().unwrap();
+        hook.as_ref().unwrap().on_panic(info.to_string());
+    }));
+}

--- a/core-bindings-c/src/qqself.udl
+++ b/core-bindings-c/src/qqself.udl
@@ -1,6 +1,7 @@
 namespace qqselfCore {
   string string_hash(string input);
   string build_info();
+  void set_panic_hook(PanicHook hook);
 
   // Static functions
   Cryptor cryptor_generate_new();
@@ -36,4 +37,8 @@ interface Cryptor {
   string sign_delete_token();
   [Throws=CryptorError]
   string sign_find_token(string? last_id);
+};
+
+callback interface PanicHook {
+    void on_panic(string msg);
 };


### PR DESCRIPTION
- `core-bindings-c` Allow clients to have their own panic handler. `uniffy` sets their own and it works fine, but in some cases like in iOS Preview hook is not set and preview crashing without any indication what went wrong. With this PR we can add `setPanicHook()` in the `#Preview` macros and then in case of panic logs will be printed e.g.
```
[9.12.2023, 9.09.24 ERROR] panicked at 'Cannot create a hash for empty data', core/src/encryption/hash.rs:24:13
```
It also should allow binding clients to implement their own crash reporting e.g. send to crash analytics server, collect additional context data, etc.