### PR TITLE
ci Try XCode 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   build-ios:
     runs-on: macos-13
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
     defaults:
       run:
         working-directory: client-ios


### PR DESCRIPTION
CI is failing almost every build for iOS, let's see if upgrading XCode would help