### PR TITLE
ci Disable client-ios tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     - run: make deps
     - run: make bindings
     - run: make build
-    - run: make test
+    - run: echo "make test is disabled. Waiting for XCode 15 fix and new agent"
     - run: make format-check
 
   deploy-api:


### PR DESCRIPTION
iOS tests fails in 99% percent of the time, no point to continue to try to run it. Let's wait for new macos-13 agent upgrade and new XCode and hope for the best